### PR TITLE
fix can't start on win32

### DIFF
--- a/backend/src/agent/providers/claude-cli.ts
+++ b/backend/src/agent/providers/claude-cli.ts
@@ -198,6 +198,7 @@ export class ClaudeCliProvider implements AgentProvider {
         env: { ...process.env },
         // On Windows, .cmd files cannot be spawned directly (CreateProcess API limitation);
         // shell: true routes through cmd.exe which can execute batch scripts.
+        shell: process.platform === 'win32',
       });
       this.process = proc;
       debug('provider', `Process spawned, pid=${proc.pid}`);


### PR DESCRIPTION
## Summary

Fix some windows user can't start claude.

## Changes

- On windows, use shell true launch via cmd.exe