### PR TITLE
Add support for custom Claude CLI args and env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,17 +126,17 @@ cc-spacemolt/
 
 ### CLI Options
 
-| Option                           | Default                                               | Description                                |
-| -------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
-| `--config-file <path>`           | `~/.cc-spacemolt/config.json`                         | Path to config file                        |
-| `--log-dir <path>`               | `~/.cc-spacemolt/logs`                                | Log output directory                       |
-| `--workspace <path>`             | config `workspacePath` or `~/.cc-spacemolt/workspace` | Working directory                          |
-| `--port <number>`                | `3001`                                                | HTTP server port                           |
-| `--host <hostname>`              | `localhost`                                           | Bind hostname                              |
-| `--debug`                        | —                                                     | Enable debug logging                       |
-| `--dangerously-skip-permissions` | —                                                     | Bypass all permissions                     |
-| `--claude-env <KEY=VALUE>`       | —                                                     | Env var for Claude CLI (repeatable)        |
-| `--claude-arg <arg>`             | —                                                     | Additional arg for Claude CLI (repeatable) |
+| Option                           | Default                                               | Description                                 |
+| -------------------------------- | ----------------------------------------------------- | ------------------------------------------- |
+| `--config-file <path>`           | `~/.cc-spacemolt/config.json`                         | Path to config file                         |
+| `--log-dir <path>`               | `~/.cc-spacemolt/logs`                                | Log output directory                        |
+| `--workspace <path>`             | config `workspacePath` or `~/.cc-spacemolt/workspace` | Working directory                           |
+| `--port <number>`                | `3001`                                                | HTTP server port                            |
+| `--host <hostname>`              | `localhost`                                           | Bind hostname                               |
+| `--debug`                        | —                                                     | Enable debug logging                        |
+| `--dangerously-skip-permissions` | —                                                     | Bypass all permissions                      |
+| `--claude-env <KEY=VALUE>`       | —                                                     | Env var for Claude CLI (repeatable)         |
+| `--claude-args <args>`           | —                                                     | Additional args for Claude CLI (repeatable) |
 
 Priority order: CLI args > config.json values > defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,16 +126,17 @@ cc-spacemolt/
 
 ### CLI Options
 
-| Option                           | Default                                               | Description            |
-| -------------------------------- | ----------------------------------------------------- | ---------------------- |
-| `--config-file <path>`           | `~/.cc-spacemolt/config.json`                         | Path to config file    |
-| `--log-dir <path>`               | `~/.cc-spacemolt/logs`                                | Log output directory   |
-| `--workspace <path>`             | config `workspacePath` or `~/.cc-spacemolt/workspace` | Working directory      |
-| `--port <number>`                | `3001`                                                | HTTP server port       |
-| `--host <hostname>`              | `localhost`                                           | Bind hostname          |
-| `--debug`                        | —                                                     | Enable debug logging   |
-| `--dangerously-skip-permissions` | —                                                     | Bypass all permissions |
-| `--claude-env <KEY=VALUE>`       | —                                                     | Env var for Claude CLI (repeatable) |
+| Option                           | Default                                               | Description                                |
+| -------------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| `--config-file <path>`           | `~/.cc-spacemolt/config.json`                         | Path to config file                        |
+| `--log-dir <path>`               | `~/.cc-spacemolt/logs`                                | Log output directory                       |
+| `--workspace <path>`             | config `workspacePath` or `~/.cc-spacemolt/workspace` | Working directory                          |
+| `--port <number>`                | `3001`                                                | HTTP server port                           |
+| `--host <hostname>`              | `localhost`                                           | Bind hostname                              |
+| `--debug`                        | —                                                     | Enable debug logging                       |
+| `--dangerously-skip-permissions` | —                                                     | Bypass all permissions                     |
+| `--claude-env <KEY=VALUE>`       | —                                                     | Env var for Claude CLI (repeatable)        |
+| `--claude-arg <arg>`             | —                                                     | Additional arg for Claude CLI (repeatable) |
 
 Priority order: CLI args > config.json values > defaults
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,8 +153,8 @@ Configure via `data/config.json` (dev) or `~/.cc-spacemolt/config.json`. Main fi
 - `workspacePath` — working directory for Claude CLI
 - `language` — response language
 - `dangerouslySkipPermissions` — bypass all permissions
-- `claudeArgs` — additional CLI arguments appended to the Claude CLI command (string[])
-- `claudeEnv` — environment variables applied when launching the Claude CLI process (Record<string, string>)
+- `claudeArgs` — additional CLI arguments appended to the Claude CLI command
+- `claudeEnv` — environment variables applied when launching the Claude CLI process
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ cc-spacemolt/
 | `--host <hostname>`              | `localhost`                                           | Bind hostname          |
 | `--debug`                        | —                                                     | Enable debug logging   |
 | `--dangerously-skip-permissions` | —                                                     | Bypass all permissions |
+| `--claude-env <KEY=VALUE>`       | —                                                     | Env var for Claude CLI (repeatable) |
 
 Priority order: CLI args > config.json values > defaults
 
@@ -151,6 +152,8 @@ Configure via `data/config.json` (dev) or `~/.cc-spacemolt/config.json`. Main fi
 - `workspacePath` — working directory for Claude CLI
 - `language` — response language
 - `dangerouslySkipPermissions` — bypass all permissions
+- `claudeArgs` — additional CLI arguments appended to the Claude CLI command (string[])
+- `claudeEnv` — environment variables applied when launching the Claude CLI process (Record<string, string>)
 
 ## Testing
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -87,23 +87,26 @@ cc-spacemolt [options]
 
 ```jsonc
 {
-  "initialPrompt": "...", // セッション開始時にエージェントへ送る最初のプロンプト
+  "initialPrompt": "...", // セッション開始時にエージェントに送られる初期プロンプト
   "systemPromptAppend": "...", // Claude Code 実行時に追加されるシステムプロンプト
   "mcpServers": {
-    // MCP サーバー設定（stdio / http / sse）
-    "my-server": { "type": "http", "url": "https://example.com/mcp" },
+    // MCP サーバーの設定
+    "spacemolt": {
+      "type": "http",
+      "url": "https://game.spacemolt.com/mcp",
+    },
   },
   "permissions": {
     "autoAllowTools": [], // 自動承認する組み込みツール名
     "allowedMcpPrefixes": ["mcp__spacemolt__"], // 自動承認する MCP ツールのプレフィックス
-    "allowedWebDomains": ["example.com"], // WebFetch / WebSearch で自動承認するドメイン
+    "allowedWebDomains": ["game.spacemolt.com", "spacemolt.com"], // WebFetch / WebSearch で自動承認するドメイン
   },
   "maxLogEntries": 1000, // メモリ上に保持するログエントリの最大数
   "model": "sonnet", // 使用する Claude モデル
   "workspacePath": "/path/to/workspace", // Claude CLI の作業ディレクトリ
-  "language": "Japanese", // エージェントとの会話言語
+  "language": "Japanese", // エージェントとの会話言語（例: "English", "Japanese"）
   "uiLanguage": "ja", // Web UI の言語（"en" または "ja"）
-  "dangerouslySkipPermissions": false, // 全ての権限確認をスキップ（十分注意してください）
+  "dangerouslySkipPermissions": false, // 全ての権限確認をスキップ（使用する場合は十分に注意してください）
   "claudeArgs": ["--verbose"], // Claude CLI コマンドに追加される引数
   "claudeEnv": { "MY_VAR": "value" }, // Claude CLI 起動時に適用される環境変数
 }

--- a/README-ja.md
+++ b/README-ja.md
@@ -76,6 +76,8 @@ cc-spacemolt [options]
 | `--host <hostname>`              | `localhost`                                                  | バインドするホスト名（0.0.0.0 で外部アクセスを許可） |
 | `--debug`                        | —                                                            | デバッグログを有効化                                 |
 | `--dangerously-skip-permissions` | —                                                            | 全ての権限確認をスキップ                             |
+| `--claude-env <KEY=VALUE>`       | —                                                            | Claude CLI 用の環境変数（繰り返し指定可）            |
+| `--claude-args <args>`           | —                                                            | Claude CLI への追加引数（繰り返し指定可）            |
 
 コマンドライン引数は設定ファイルの内容より優先されます。
 
@@ -97,6 +99,8 @@ cc-spacemolt [options]
 | `language`                       | エージェントとの会話言語（例: `"Japanese"`）                         |
 | `uiLanguage`                     | Web UI セットアップウィザードの言語（`"en"` または `"ja"`）          |
 | `dangerouslySkipPermissions`     | 全ての権限確認をスキップ（`true` にする場合は十分注意してください）  |
+| `claudeArgs`                     | Claude CLI コマンドに追加される引数                                  |
+| `claudeEnv`                      | Claude CLI 起動時に適用される環境変数                                |
 
 ## 開発
 

--- a/README-ja.md
+++ b/README-ja.md
@@ -85,22 +85,29 @@ cc-spacemolt [options]
 
 `~/.cc-spacemolt/config.json`（開発時は `data/config.json`）で動作を設定します。
 
-| フィールド                       | 説明                                                                 |
-| -------------------------------- | -------------------------------------------------------------------- |
-| `initialPrompt`                  | セッション開始時にエージェントへ送る最初のプロンプト（デフォルト値） |
-| `systemPromptAppend`             | Claude Code実行時の追加のシステムプロンプト                          |
-| `mcpServers`                     | MCP サーバー設定（`stdio` / `http` / `sse`）                         |
-| `permissions.autoAllowTools`     | 自動承認される組み込みツール名のリスト                               |
-| `permissions.allowedMcpPrefixes` | 自動承認される MCP ツールのプレフィックス                            |
-| `permissions.allowedWebDomains`  | WebFetch / WebSearch で自動承認するドメイン                          |
-| `maxLogEntries`                  | メモリ上に保持するログエントリの最大数                               |
-| `model`                          | 使用する Claude モデル                                               |
-| `workspacePath`                  | Claude CLI の作業ディレクトリ（未指定時はデフォルトディレクトリ）    |
-| `language`                       | エージェントとの会話言語（例: `"Japanese"`）                         |
-| `uiLanguage`                     | Web UI セットアップウィザードの言語（`"en"` または `"ja"`）          |
-| `dangerouslySkipPermissions`     | 全ての権限確認をスキップ（`true` にする場合は十分注意してください）  |
-| `claudeArgs`                     | Claude CLI コマンドに追加される引数                                  |
-| `claudeEnv`                      | Claude CLI 起動時に適用される環境変数                                |
+```jsonc
+{
+  "initialPrompt": "...", // セッション開始時にエージェントへ送る最初のプロンプト
+  "systemPromptAppend": "...", // Claude Code 実行時に追加されるシステムプロンプト
+  "mcpServers": {
+    // MCP サーバー設定（stdio / http / sse）
+    "my-server": { "type": "http", "url": "https://example.com/mcp" },
+  },
+  "permissions": {
+    "autoAllowTools": [], // 自動承認する組み込みツール名
+    "allowedMcpPrefixes": ["mcp__spacemolt__"], // 自動承認する MCP ツールのプレフィックス
+    "allowedWebDomains": ["example.com"], // WebFetch / WebSearch で自動承認するドメイン
+  },
+  "maxLogEntries": 1000, // メモリ上に保持するログエントリの最大数
+  "model": "sonnet", // 使用する Claude モデル
+  "workspacePath": "/path/to/workspace", // Claude CLI の作業ディレクトリ
+  "language": "Japanese", // エージェントとの会話言語
+  "uiLanguage": "ja", // Web UI の言語（"en" または "ja"）
+  "dangerouslySkipPermissions": false, // 全ての権限確認をスキップ（十分注意してください）
+  "claudeArgs": ["--verbose"], // Claude CLI コマンドに追加される引数
+  "claudeEnv": { "MY_VAR": "value" }, // Claude CLI 起動時に適用される環境変数
+}
+```
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -85,22 +85,29 @@ Command-line arguments override values in the config file.
 
 Configure behavior via `~/.cc-spacemolt/config.json` (or `data/config.json` during development).
 
-| Field                            | Description                                                 |
-| -------------------------------- | ----------------------------------------------------------- |
-| `initialPrompt`                  | Default initial prompt sent to the agent at session start   |
-| `systemPromptAppend`             | Additional system prompt appended when running Claude Code  |
-| `mcpServers`                     | MCP server configuration (`stdio` / `http` / `sse`)         |
-| `permissions.autoAllowTools`     | List of built-in tool names to auto-approve                 |
-| `permissions.allowedMcpPrefixes` | MCP tool prefixes to auto-approve                           |
-| `permissions.allowedWebDomains`  | Domains to auto-approve for WebFetch / WebSearch            |
-| `maxLogEntries`                  | Maximum number of log entries to keep in memory             |
-| `model`                          | Claude model to use                                         |
-| `workspacePath`                  | Working directory for Claude CLI (uses default if not set)  |
-| `language`                       | Language for agent responses (e.g., `"Japanese"`)           |
-| `uiLanguage`                     | Language for the Web UI setup wizard (`"en"` or `"ja"`)     |
-| `dangerouslySkipPermissions`     | Bypass all permission checks (use with caution)             |
-| `claudeArgs`                     | Additional CLI arguments appended to the Claude CLI command |
-| `claudeEnv`                      | Environment variables applied when launching Claude CLI     |
+```jsonc
+{
+  "initialPrompt": "...", // Default initial prompt sent to the agent at session start
+  "systemPromptAppend": "...", // Additional system prompt appended when running Claude Code
+  "mcpServers": {
+    // MCP server configuration (stdio / http / sse)
+    "my-server": { "type": "http", "url": "https://example.com/mcp" },
+  },
+  "permissions": {
+    "autoAllowTools": [], // Built-in tool names to auto-approve
+    "allowedMcpPrefixes": ["mcp__spacemolt__"], // MCP tool prefixes to auto-approve
+    "allowedWebDomains": ["example.com"], // Domains to auto-approve for WebFetch / WebSearch
+  },
+  "maxLogEntries": 1000, // Maximum number of log entries to keep in memory
+  "model": "sonnet", // Claude model to use
+  "workspacePath": "/path/to/workspace", // Working directory for Claude CLI
+  "language": "English", // Language for agent responses
+  "uiLanguage": "en", // Language for the Web UI setup wizard ("en" or "ja")
+  "dangerouslySkipPermissions": false, // Bypass all permission checks (use with caution)
+  "claudeArgs": ["--verbose"], // Additional CLI arguments appended to the Claude CLI command
+  "claudeEnv": { "MY_VAR": "value" }, // Environment variables applied when launching Claude CLI
+}
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cc-spacemolt [options]
 | `--host <hostname>`              | `localhost`                                           | Bind hostname (use `0.0.0.0` to allow external access) |
 | `--debug`                        | —                                                     | Enable debug logging                                   |
 | `--dangerously-skip-permissions` | —                                                     | Bypass all permission checks                           |
+| `--claude-env <KEY=VALUE>`       | —                                                     | Env var for Claude CLI (repeatable)                    |
+| `--claude-args <args>`           | —                                                     | Additional args for Claude CLI (repeatable)            |
 
 Command-line arguments override values in the config file.
 
@@ -83,20 +85,22 @@ Command-line arguments override values in the config file.
 
 Configure behavior via `~/.cc-spacemolt/config.json` (or `data/config.json` during development).
 
-| Field                            | Description                                                |
-| -------------------------------- | ---------------------------------------------------------- |
-| `initialPrompt`                  | Default initial prompt sent to the agent at session start  |
-| `systemPromptAppend`             | Additional system prompt appended when running Claude Code |
-| `mcpServers`                     | MCP server configuration (`stdio` / `http` / `sse`)        |
-| `permissions.autoAllowTools`     | List of built-in tool names to auto-approve                |
-| `permissions.allowedMcpPrefixes` | MCP tool prefixes to auto-approve                          |
-| `permissions.allowedWebDomains`  | Domains to auto-approve for WebFetch / WebSearch           |
-| `maxLogEntries`                  | Maximum number of log entries to keep in memory            |
-| `model`                          | Claude model to use                                        |
-| `workspacePath`                  | Working directory for Claude CLI (uses default if not set) |
-| `language`                       | Language for agent responses (e.g., `"Japanese"`)          |
-| `uiLanguage`                     | Language for the Web UI setup wizard (`"en"` or `"ja"`)    |
-| `dangerouslySkipPermissions`     | Bypass all permission checks (use with caution)            |
+| Field                            | Description                                                 |
+| -------------------------------- | ----------------------------------------------------------- |
+| `initialPrompt`                  | Default initial prompt sent to the agent at session start   |
+| `systemPromptAppend`             | Additional system prompt appended when running Claude Code  |
+| `mcpServers`                     | MCP server configuration (`stdio` / `http` / `sse`)         |
+| `permissions.autoAllowTools`     | List of built-in tool names to auto-approve                 |
+| `permissions.allowedMcpPrefixes` | MCP tool prefixes to auto-approve                           |
+| `permissions.allowedWebDomains`  | Domains to auto-approve for WebFetch / WebSearch            |
+| `maxLogEntries`                  | Maximum number of log entries to keep in memory             |
+| `model`                          | Claude model to use                                         |
+| `workspacePath`                  | Working directory for Claude CLI (uses default if not set)  |
+| `language`                       | Language for agent responses (e.g., `"Japanese"`)           |
+| `uiLanguage`                     | Language for the Web UI setup wizard (`"en"` or `"ja"`)     |
+| `dangerouslySkipPermissions`     | Bypass all permission checks (use with caution)             |
+| `claudeArgs`                     | Additional CLI arguments appended to the Claude CLI command |
+| `claudeEnv`                      | Environment variables applied when launching Claude CLI     |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -90,18 +90,21 @@ Configure behavior via `~/.cc-spacemolt/config.json` (or `data/config.json` duri
   "initialPrompt": "...", // Default initial prompt sent to the agent at session start
   "systemPromptAppend": "...", // Additional system prompt appended when running Claude Code
   "mcpServers": {
-    // MCP server configuration (stdio / http / sse)
-    "my-server": { "type": "http", "url": "https://example.com/mcp" },
+    // MCP server configuration
+    "spacemolt": {
+      "type": "http",
+      "url": "https://game.spacemolt.com/mcp",
+    },
   },
   "permissions": {
-    "autoAllowTools": [], // Built-in tool names to auto-approve
+    "autoAllowTools": [], // Tool names to auto-approve
     "allowedMcpPrefixes": ["mcp__spacemolt__"], // MCP tool prefixes to auto-approve
-    "allowedWebDomains": ["example.com"], // Domains to auto-approve for WebFetch / WebSearch
+    "allowedWebDomains": ["game.spacemolt.com", "spacemolt.com"], // Domains to auto-approve for WebFetch / WebSearch
   },
-  "maxLogEntries": 1000, // Maximum number of log entries to keep in memory
+  "maxLogEntries": 1000, // Maximum number of conversation log entries to keep
   "model": "sonnet", // Claude model to use
-  "workspacePath": "/path/to/workspace", // Working directory for Claude CLI
-  "language": "English", // Language for agent responses
+  "workspacePath": "/path/to/workspace", // Working directory for Claude Code
+  "language": "English", // Language for agent responses (e.g. "English", "Japanese")
   "uiLanguage": "en", // Language for the Web UI setup wizard ("en" or "ja")
   "dangerouslySkipPermissions": false, // Bypass all permission checks (use with caution)
   "claudeArgs": ["--verbose"], // Additional CLI arguments appended to the Claude CLI command

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@cc-spacemolt/shared": "*",
+    "@commander-js/extra-typings": "^14.0.0",
     "@hono/node-server": "^1.14.0",
     "@inquirer/prompts": "^8.2.1",
     "commander": "^14.0.3",

--- a/backend/src/agent/providers/claude-cli.ts
+++ b/backend/src/agent/providers/claude-cli.ts
@@ -155,6 +155,11 @@ export class ClaudeCliProvider implements AgentProvider {
       args.push('--resume', resumeId);
     }
 
+    // Custom args from config (appended last)
+    if (this.config.claudeArgs && this.config.claudeArgs.length > 0) {
+      args.push(...this.config.claudeArgs);
+    }
+
     return args;
   }
 
@@ -192,7 +197,7 @@ export class ClaudeCliProvider implements AgentProvider {
       const proc = spawn('claude', args, {
         stdio: ['pipe', 'pipe', 'pipe'],
         cwd,
-        env: { ...process.env },
+        env: { ...process.env, ...this.config.claudeEnv },
       });
       this.process = proc;
       debug('provider', `Process spawned, pid=${proc.pid}`);

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { loadConfig } from './config.js';
+
+function createTempConfig(content: object): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-spacemolt-test-'));
+  const file = path.join(dir, 'config.json');
+  fs.writeFileSync(file, JSON.stringify(content), 'utf-8');
+  return file;
+}
+
+describe('loadConfig', () => {
+  describe('claudeArgs', () => {
+    it('defaults to undefined when not specified', () => {
+      const config = loadConfig(createTempConfig({}));
+      expect(config.claudeArgs).toBeUndefined();
+    });
+
+    it('loads claudeArgs from config file', () => {
+      const config = loadConfig(
+        createTempConfig({ claudeArgs: ['--max-turns', '50', '--verbose'] }),
+      );
+      expect(config.claudeArgs).toEqual(['--max-turns', '50', '--verbose']);
+    });
+  });
+
+  describe('claudeEnv', () => {
+    it('defaults to undefined when not specified', () => {
+      const config = loadConfig(createTempConfig({}));
+      expect(config.claudeEnv).toBeUndefined();
+    });
+
+    it('loads claudeEnv from config file', () => {
+      const config = loadConfig(
+        createTempConfig({ claudeEnv: { ANTHROPIC_API_KEY: 'sk-test', NODE_ENV: 'production' } }),
+      );
+      expect(config.claudeEnv).toEqual({
+        ANTHROPIC_API_KEY: 'sk-test',
+        NODE_ENV: 'production',
+      });
+    });
+  });
+});

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { loadConfig, applyCliOverrides, DEFAULT_CONFIG } from './config.js';
+import type { CommandLineOptions } from './utils/command-line.js';
 import type { AppConfig } from './config.js';
 
 function createTempConfig(content: object): string {
@@ -17,6 +18,22 @@ function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
 }
 
 const FAKE_CONFIG_DIR = '/fake/config/dir';
+const FAKE_CONFIG_FILE = path.join(FAKE_CONFIG_DIR, 'config.json');
+
+function makeCliOptions(overrides: Partial<CommandLineOptions> = {}): CommandLineOptions {
+  return {
+    configFile: FAKE_CONFIG_FILE,
+    logDir: undefined,
+    workspace: undefined,
+    port: 3001,
+    host: 'localhost',
+    debug: undefined,
+    dangerouslySkipPermissions: undefined,
+    claudeEnv: {},
+    claudeArgs: [],
+    ...overrides,
+  };
+}
 
 describe('loadConfig', () => {
   it('returns defaults for empty config', () => {
@@ -42,38 +59,40 @@ describe('applyCliOverrides', () => {
   describe('workspacePath', () => {
     it('CLI workspace overrides config workspacePath', () => {
       const config = makeConfig({ workspacePath: '/config/workspace' });
-      const result = applyCliOverrides(config, { workspace: '/cli/workspace' }, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(
+        config,
+        makeCliOptions({ workspace: '/cli/workspace' }),
+        FAKE_CONFIG_DIR,
+      );
       expect(result.workspacePath).toBe('/cli/workspace');
       expect(result.config.workspacePath).toBe('/cli/workspace');
     });
 
     it('config workspacePath is used when CLI workspace is not provided', () => {
       const config = makeConfig({ workspacePath: '/config/workspace' });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(config, makeCliOptions(), FAKE_CONFIG_DIR);
       expect(result.workspacePath).toBe('/config/workspace');
     });
 
     it('falls back to default when config workspacePath is empty string', () => {
       const config = makeConfig({ workspacePath: '' });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
-      expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
-    });
-
-    it('falls back to default when config workspacePath is undefined', () => {
-      const config = makeConfig({ workspacePath: undefined });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(config, makeCliOptions(), FAKE_CONFIG_DIR);
       expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
     });
   });
 
   describe('logDir', () => {
     it('CLI logDir overrides default', () => {
-      const result = applyCliOverrides(makeConfig(), { logDir: '/cli/logs' }, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(
+        makeConfig(),
+        makeCliOptions({ logDir: '/cli/logs' }),
+        FAKE_CONFIG_DIR,
+      );
       expect(result.logDir).toBe('/cli/logs');
     });
 
     it('falls back to default when CLI logDir is not provided', () => {
-      const result = applyCliOverrides(makeConfig(), {}, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(makeConfig(), makeCliOptions(), FAKE_CONFIG_DIR);
       expect(result.logDir).toBe(path.join(FAKE_CONFIG_DIR, 'logs'));
     });
   });
@@ -82,7 +101,7 @@ describe('applyCliOverrides', () => {
     it('is true when CLI flag is set', () => {
       const result = applyCliOverrides(
         makeConfig({ dangerouslySkipPermissions: false }),
-        { dangerouslySkipPermissions: true },
+        makeCliOptions({ dangerouslySkipPermissions: true }),
         FAKE_CONFIG_DIR,
       );
       expect(result.bypassPermissions).toBe(true);
@@ -91,7 +110,7 @@ describe('applyCliOverrides', () => {
     it('is true when config flag is set', () => {
       const result = applyCliOverrides(
         makeConfig({ dangerouslySkipPermissions: true }),
-        {},
+        makeCliOptions(),
         FAKE_CONFIG_DIR,
       );
       expect(result.bypassPermissions).toBe(true);
@@ -100,7 +119,7 @@ describe('applyCliOverrides', () => {
     it('is true when both flags are set', () => {
       const result = applyCliOverrides(
         makeConfig({ dangerouslySkipPermissions: true }),
-        { dangerouslySkipPermissions: true },
+        makeCliOptions({ dangerouslySkipPermissions: true }),
         FAKE_CONFIG_DIR,
       );
       expect(result.bypassPermissions).toBe(true);
@@ -109,7 +128,7 @@ describe('applyCliOverrides', () => {
     it('is false when neither flag is set', () => {
       const result = applyCliOverrides(
         makeConfig({ dangerouslySkipPermissions: false }),
-        {},
+        makeCliOptions(),
         FAKE_CONFIG_DIR,
       );
       expect(result.bypassPermissions).toBe(false);
@@ -119,25 +138,33 @@ describe('applyCliOverrides', () => {
   describe('claudeEnv', () => {
     it('CLI env overrides config env on key conflict', () => {
       const config = makeConfig({ claudeEnv: { KEY: 'from-config', OTHER: 'keep' } });
-      const result = applyCliOverrides(config, { claudeEnv: { KEY: 'from-cli' } }, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(
+        config,
+        makeCliOptions({ claudeEnv: { KEY: 'from-cli' } }),
+        FAKE_CONFIG_DIR,
+      );
       expect(result.config.claudeEnv).toEqual({ KEY: 'from-cli', OTHER: 'keep' });
     });
 
     it('CLI env adds new keys alongside config env', () => {
       const config = makeConfig({ claudeEnv: { EXISTING: 'val' } });
-      const result = applyCliOverrides(config, { claudeEnv: { NEW: 'cli-val' } }, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(
+        config,
+        makeCliOptions({ claudeEnv: { NEW: 'cli-val' } }),
+        FAKE_CONFIG_DIR,
+      );
       expect(result.config.claudeEnv).toEqual({ EXISTING: 'val', NEW: 'cli-val' });
     });
 
     it('config env is preserved when no CLI env is provided', () => {
       const config = makeConfig({ claudeEnv: { FOO: 'bar' } });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(config, makeCliOptions(), FAKE_CONFIG_DIR);
       expect(result.config.claudeEnv).toEqual({ FOO: 'bar' });
     });
 
     it('empty CLI env object does not clear config env', () => {
       const config = makeConfig({ claudeEnv: { FOO: 'bar' } });
-      const result = applyCliOverrides(config, { claudeEnv: {} }, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(config, makeCliOptions({ claudeEnv: {} }), FAKE_CONFIG_DIR);
       expect(result.config.claudeEnv).toEqual({ FOO: 'bar' });
     });
   });
@@ -145,34 +172,19 @@ describe('applyCliOverrides', () => {
   describe('claudeArgs', () => {
     it('CLI args are appended after config args', () => {
       const config = makeConfig({ claudeArgs: ['--config-arg'] });
-      const result = applyCliOverrides(config, { claudeArgs: ['--cli-arg'] }, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(
+        config,
+        makeCliOptions({ claudeArgs: ['--cli-arg'] }),
+        FAKE_CONFIG_DIR,
+      );
       expect(result.config.claudeArgs).toEqual(['--config-arg', '--cli-arg']);
-    });
-
-    it('CLI args work when config has no args', () => {
-      const config = makeConfig({ claudeArgs: undefined });
-      const result = applyCliOverrides(config, { claudeArgs: ['--cli-arg'] }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeArgs).toEqual(['--cli-arg']);
     });
 
     it('config args are preserved when no CLI args are provided', () => {
       const config = makeConfig({ claudeArgs: ['--config-arg'] });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      const result = applyCliOverrides(config, makeCliOptions(), FAKE_CONFIG_DIR);
       expect(result.config.claudeArgs).toEqual(['--config-arg']);
     });
-
-    it('empty CLI args array does not modify config args', () => {
-      const config = makeConfig({ claudeArgs: ['--config-arg'] });
-      const result = applyCliOverrides(config, { claudeArgs: [] }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeArgs).toEqual(['--config-arg']);
-    });
-  });
-
-  it('does not mutate input config', () => {
-    const config = makeConfig({ claudeEnv: { KEY: 'original' } });
-    const result = applyCliOverrides(config, { claudeEnv: { KEY: 'overridden' } }, FAKE_CONFIG_DIR);
-    expect(result.config).not.toBe(config);
-    expect(config.claudeEnv).toEqual({ KEY: 'original' });
   });
 
   it('resolves full priority chain: CLI > config > default', () => {
@@ -185,13 +197,13 @@ describe('applyCliOverrides', () => {
 
     const result = applyCliOverrides(
       config,
-      {
+      makeCliOptions({
         workspace: '/cli/ws',
         logDir: '/cli/logs',
         dangerouslySkipPermissions: true,
         claudeEnv: { B: 'cli', C: 'cli' },
         claudeArgs: ['--from-cli'],
-      },
+      }),
       FAKE_CONFIG_DIR,
     );
 

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -77,7 +77,7 @@ describe('applyCliOverrides', () => {
     it('falls back to default when config workspacePath is empty string', () => {
       const config = makeConfig({ workspacePath: '' });
       const result = applyCliOverrides(config, makeCliOptions(), FAKE_CONFIG_DIR);
-      expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
+      expect(result.workspacePath).toBe(path.join(os.homedir(), '.cc-spacemolt', 'workspace'));
     });
   });
 

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { loadConfig, DEFAULT_CONFIG } from './config.js';
+import { loadConfig, applyCliOverrides, DEFAULT_CONFIG } from './config.js';
+import type { AppConfig } from './config.js';
 
 function createTempConfig(content: object): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-spacemolt-test-'));
@@ -10,6 +11,12 @@ function createTempConfig(content: object): string {
   fs.writeFileSync(file, JSON.stringify(content), 'utf-8');
   return file;
 }
+
+function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return { ...DEFAULT_CONFIG, ...overrides };
+}
+
+const FAKE_CONFIG_DIR = '/fake/config/dir';
 
 describe('loadConfig', () => {
   it('returns defaults for empty config', () => {
@@ -25,8 +32,173 @@ describe('loadConfig', () => {
     expect(config.initialPrompt).toBe(DEFAULT_CONFIG.initialPrompt);
   });
 
-  it('merges claudeEnv with defaults', () => {
+  it('merges claudeEnv from config file', () => {
     const config = loadConfig(createTempConfig({ claudeEnv: { FOO: 'bar' } }));
     expect(config.claudeEnv).toEqual({ FOO: 'bar' });
+  });
+});
+
+describe('applyCliOverrides', () => {
+  describe('workspacePath', () => {
+    it('CLI workspace overrides config workspacePath', () => {
+      const config = makeConfig({ workspacePath: '/config/workspace' });
+      const result = applyCliOverrides(config, { workspace: '/cli/workspace' }, FAKE_CONFIG_DIR);
+      expect(result.workspacePath).toBe('/cli/workspace');
+      expect(result.config.workspacePath).toBe('/cli/workspace');
+    });
+
+    it('config workspacePath is used when CLI workspace is not provided', () => {
+      const config = makeConfig({ workspacePath: '/config/workspace' });
+      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      expect(result.workspacePath).toBe('/config/workspace');
+    });
+
+    it('falls back to default when config workspacePath is empty string', () => {
+      const config = makeConfig({ workspacePath: '' });
+      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
+    });
+
+    it('falls back to default when config workspacePath is undefined', () => {
+      const config = makeConfig({ workspacePath: undefined });
+      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
+    });
+  });
+
+  describe('logDir', () => {
+    it('CLI logDir overrides default', () => {
+      const result = applyCliOverrides(makeConfig(), { logDir: '/cli/logs' }, FAKE_CONFIG_DIR);
+      expect(result.logDir).toBe('/cli/logs');
+    });
+
+    it('falls back to default when CLI logDir is not provided', () => {
+      const result = applyCliOverrides(makeConfig(), {}, FAKE_CONFIG_DIR);
+      expect(result.logDir).toBe(path.join(FAKE_CONFIG_DIR, 'logs'));
+    });
+  });
+
+  describe('bypassPermissions', () => {
+    it('is true when CLI flag is set', () => {
+      const result = applyCliOverrides(
+        makeConfig({ dangerouslySkipPermissions: false }),
+        { dangerouslySkipPermissions: true },
+        FAKE_CONFIG_DIR,
+      );
+      expect(result.bypassPermissions).toBe(true);
+    });
+
+    it('is true when config flag is set', () => {
+      const result = applyCliOverrides(
+        makeConfig({ dangerouslySkipPermissions: true }),
+        {},
+        FAKE_CONFIG_DIR,
+      );
+      expect(result.bypassPermissions).toBe(true);
+    });
+
+    it('is true when both flags are set', () => {
+      const result = applyCliOverrides(
+        makeConfig({ dangerouslySkipPermissions: true }),
+        { dangerouslySkipPermissions: true },
+        FAKE_CONFIG_DIR,
+      );
+      expect(result.bypassPermissions).toBe(true);
+    });
+
+    it('is false when neither flag is set', () => {
+      const result = applyCliOverrides(
+        makeConfig({ dangerouslySkipPermissions: false }),
+        {},
+        FAKE_CONFIG_DIR,
+      );
+      expect(result.bypassPermissions).toBe(false);
+    });
+  });
+
+  describe('claudeEnv', () => {
+    it('CLI env overrides config env on key conflict', () => {
+      const config = makeConfig({ claudeEnv: { KEY: 'from-config', OTHER: 'keep' } });
+      const result = applyCliOverrides(config, { claudeEnv: { KEY: 'from-cli' } }, FAKE_CONFIG_DIR);
+      expect(result.config.claudeEnv).toEqual({ KEY: 'from-cli', OTHER: 'keep' });
+    });
+
+    it('CLI env adds new keys alongside config env', () => {
+      const config = makeConfig({ claudeEnv: { EXISTING: 'val' } });
+      const result = applyCliOverrides(config, { claudeEnv: { NEW: 'cli-val' } }, FAKE_CONFIG_DIR);
+      expect(result.config.claudeEnv).toEqual({ EXISTING: 'val', NEW: 'cli-val' });
+    });
+
+    it('config env is preserved when no CLI env is provided', () => {
+      const config = makeConfig({ claudeEnv: { FOO: 'bar' } });
+      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      expect(result.config.claudeEnv).toEqual({ FOO: 'bar' });
+    });
+
+    it('empty CLI env object does not clear config env', () => {
+      const config = makeConfig({ claudeEnv: { FOO: 'bar' } });
+      const result = applyCliOverrides(config, { claudeEnv: {} }, FAKE_CONFIG_DIR);
+      expect(result.config.claudeEnv).toEqual({ FOO: 'bar' });
+    });
+  });
+
+  describe('claudeArgs', () => {
+    it('CLI args are appended after config args', () => {
+      const config = makeConfig({ claudeArgs: ['--config-arg'] });
+      const result = applyCliOverrides(config, { claudeArgs: ['--cli-arg'] }, FAKE_CONFIG_DIR);
+      expect(result.config.claudeArgs).toEqual(['--config-arg', '--cli-arg']);
+    });
+
+    it('CLI args work when config has no args', () => {
+      const config = makeConfig({ claudeArgs: undefined });
+      const result = applyCliOverrides(config, { claudeArgs: ['--cli-arg'] }, FAKE_CONFIG_DIR);
+      expect(result.config.claudeArgs).toEqual(['--cli-arg']);
+    });
+
+    it('config args are preserved when no CLI args are provided', () => {
+      const config = makeConfig({ claudeArgs: ['--config-arg'] });
+      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
+      expect(result.config.claudeArgs).toEqual(['--config-arg']);
+    });
+
+    it('empty CLI args array does not modify config args', () => {
+      const config = makeConfig({ claudeArgs: ['--config-arg'] });
+      const result = applyCliOverrides(config, { claudeArgs: [] }, FAKE_CONFIG_DIR);
+      expect(result.config.claudeArgs).toEqual(['--config-arg']);
+    });
+  });
+
+  it('does not mutate input config', () => {
+    const config = makeConfig({ claudeEnv: { KEY: 'original' } });
+    const result = applyCliOverrides(config, { claudeEnv: { KEY: 'overridden' } }, FAKE_CONFIG_DIR);
+    expect(result.config).not.toBe(config);
+    expect(config.claudeEnv).toEqual({ KEY: 'original' });
+  });
+
+  it('resolves full priority chain: CLI > config > default', () => {
+    const config = makeConfig({
+      workspacePath: '/config/ws',
+      dangerouslySkipPermissions: false,
+      claudeEnv: { A: 'config', B: 'config' },
+      claudeArgs: ['--from-config'],
+    });
+
+    const result = applyCliOverrides(
+      config,
+      {
+        workspace: '/cli/ws',
+        logDir: '/cli/logs',
+        dangerouslySkipPermissions: true,
+        claudeEnv: { B: 'cli', C: 'cli' },
+        claudeArgs: ['--from-cli'],
+      },
+      FAKE_CONFIG_DIR,
+    );
+
+    expect(result.workspacePath).toBe('/cli/ws');
+    expect(result.logDir).toBe('/cli/logs');
+    expect(result.bypassPermissions).toBe(true);
+    expect(result.config.claudeEnv).toEqual({ A: 'config', B: 'cli', C: 'cli' });
+    expect(result.config.claudeArgs).toEqual(['--from-config', '--from-cli']);
   });
 });

--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -2,8 +2,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { loadConfig, applyCliOverrides, DEFAULT_CONFIG } from './config.js';
-import type { AppConfig } from './config.js';
+import { loadConfig, DEFAULT_CONFIG } from './config.js';
 
 function createTempConfig(content: object): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-spacemolt-test-'));
@@ -11,12 +10,6 @@ function createTempConfig(content: object): string {
   fs.writeFileSync(file, JSON.stringify(content), 'utf-8');
   return file;
 }
-
-function makeConfig(overrides: Partial<AppConfig> = {}): AppConfig {
-  return { ...DEFAULT_CONFIG, ...overrides };
-}
-
-const FAKE_CONFIG_DIR = '/fake/config/dir';
 
 describe('loadConfig', () => {
   it('returns defaults for empty config', () => {
@@ -32,173 +25,8 @@ describe('loadConfig', () => {
     expect(config.initialPrompt).toBe(DEFAULT_CONFIG.initialPrompt);
   });
 
-  it('merges claudeEnv from config file', () => {
+  it('merges claudeEnv with defaults', () => {
     const config = loadConfig(createTempConfig({ claudeEnv: { FOO: 'bar' } }));
     expect(config.claudeEnv).toEqual({ FOO: 'bar' });
-  });
-});
-
-describe('applyCliOverrides', () => {
-  describe('workspacePath', () => {
-    it('CLI workspace overrides config workspacePath', () => {
-      const config = makeConfig({ workspacePath: '/config/workspace' });
-      const result = applyCliOverrides(config, { workspace: '/cli/workspace' }, FAKE_CONFIG_DIR);
-      expect(result.workspacePath).toBe('/cli/workspace');
-      expect(result.config.workspacePath).toBe('/cli/workspace');
-    });
-
-    it('config workspacePath is used when CLI workspace is not provided', () => {
-      const config = makeConfig({ workspacePath: '/config/workspace' });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
-      expect(result.workspacePath).toBe('/config/workspace');
-    });
-
-    it('falls back to default when config workspacePath is empty string', () => {
-      const config = makeConfig({ workspacePath: '' });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
-      expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
-    });
-
-    it('falls back to default when config workspacePath is undefined', () => {
-      const config = makeConfig({ workspacePath: undefined });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
-      expect(result.workspacePath).toBe(path.join(FAKE_CONFIG_DIR, 'workspace'));
-    });
-  });
-
-  describe('logDir', () => {
-    it('CLI logDir overrides default', () => {
-      const result = applyCliOverrides(makeConfig(), { logDir: '/cli/logs' }, FAKE_CONFIG_DIR);
-      expect(result.logDir).toBe('/cli/logs');
-    });
-
-    it('falls back to default when CLI logDir is not provided', () => {
-      const result = applyCliOverrides(makeConfig(), {}, FAKE_CONFIG_DIR);
-      expect(result.logDir).toBe(path.join(FAKE_CONFIG_DIR, 'logs'));
-    });
-  });
-
-  describe('bypassPermissions', () => {
-    it('is true when CLI flag is set', () => {
-      const result = applyCliOverrides(
-        makeConfig({ dangerouslySkipPermissions: false }),
-        { dangerouslySkipPermissions: true },
-        FAKE_CONFIG_DIR,
-      );
-      expect(result.bypassPermissions).toBe(true);
-    });
-
-    it('is true when config flag is set', () => {
-      const result = applyCliOverrides(
-        makeConfig({ dangerouslySkipPermissions: true }),
-        {},
-        FAKE_CONFIG_DIR,
-      );
-      expect(result.bypassPermissions).toBe(true);
-    });
-
-    it('is true when both flags are set', () => {
-      const result = applyCliOverrides(
-        makeConfig({ dangerouslySkipPermissions: true }),
-        { dangerouslySkipPermissions: true },
-        FAKE_CONFIG_DIR,
-      );
-      expect(result.bypassPermissions).toBe(true);
-    });
-
-    it('is false when neither flag is set', () => {
-      const result = applyCliOverrides(
-        makeConfig({ dangerouslySkipPermissions: false }),
-        {},
-        FAKE_CONFIG_DIR,
-      );
-      expect(result.bypassPermissions).toBe(false);
-    });
-  });
-
-  describe('claudeEnv', () => {
-    it('CLI env overrides config env on key conflict', () => {
-      const config = makeConfig({ claudeEnv: { KEY: 'from-config', OTHER: 'keep' } });
-      const result = applyCliOverrides(config, { claudeEnv: { KEY: 'from-cli' } }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeEnv).toEqual({ KEY: 'from-cli', OTHER: 'keep' });
-    });
-
-    it('CLI env adds new keys alongside config env', () => {
-      const config = makeConfig({ claudeEnv: { EXISTING: 'val' } });
-      const result = applyCliOverrides(config, { claudeEnv: { NEW: 'cli-val' } }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeEnv).toEqual({ EXISTING: 'val', NEW: 'cli-val' });
-    });
-
-    it('config env is preserved when no CLI env is provided', () => {
-      const config = makeConfig({ claudeEnv: { FOO: 'bar' } });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
-      expect(result.config.claudeEnv).toEqual({ FOO: 'bar' });
-    });
-
-    it('empty CLI env object does not clear config env', () => {
-      const config = makeConfig({ claudeEnv: { FOO: 'bar' } });
-      const result = applyCliOverrides(config, { claudeEnv: {} }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeEnv).toEqual({ FOO: 'bar' });
-    });
-  });
-
-  describe('claudeArgs', () => {
-    it('CLI args are appended after config args', () => {
-      const config = makeConfig({ claudeArgs: ['--config-arg'] });
-      const result = applyCliOverrides(config, { claudeArgs: ['--cli-arg'] }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeArgs).toEqual(['--config-arg', '--cli-arg']);
-    });
-
-    it('CLI args work when config has no args', () => {
-      const config = makeConfig({ claudeArgs: undefined });
-      const result = applyCliOverrides(config, { claudeArgs: ['--cli-arg'] }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeArgs).toEqual(['--cli-arg']);
-    });
-
-    it('config args are preserved when no CLI args are provided', () => {
-      const config = makeConfig({ claudeArgs: ['--config-arg'] });
-      const result = applyCliOverrides(config, {}, FAKE_CONFIG_DIR);
-      expect(result.config.claudeArgs).toEqual(['--config-arg']);
-    });
-
-    it('empty CLI args array does not modify config args', () => {
-      const config = makeConfig({ claudeArgs: ['--config-arg'] });
-      const result = applyCliOverrides(config, { claudeArgs: [] }, FAKE_CONFIG_DIR);
-      expect(result.config.claudeArgs).toEqual(['--config-arg']);
-    });
-  });
-
-  it('does not mutate input config', () => {
-    const config = makeConfig({ claudeEnv: { KEY: 'original' } });
-    const result = applyCliOverrides(config, { claudeEnv: { KEY: 'overridden' } }, FAKE_CONFIG_DIR);
-    expect(result.config).not.toBe(config);
-    expect(config.claudeEnv).toEqual({ KEY: 'original' });
-  });
-
-  it('resolves full priority chain: CLI > config > default', () => {
-    const config = makeConfig({
-      workspacePath: '/config/ws',
-      dangerouslySkipPermissions: false,
-      claudeEnv: { A: 'config', B: 'config' },
-      claudeArgs: ['--from-config'],
-    });
-
-    const result = applyCliOverrides(
-      config,
-      {
-        workspace: '/cli/ws',
-        logDir: '/cli/logs',
-        dangerouslySkipPermissions: true,
-        claudeEnv: { B: 'cli', C: 'cli' },
-        claudeArgs: ['--from-cli'],
-      },
-      FAKE_CONFIG_DIR,
-    );
-
-    expect(result.workspacePath).toBe('/cli/ws');
-    expect(result.logDir).toBe('/cli/logs');
-    expect(result.bypassPermissions).toBe(true);
-    expect(result.config.claudeEnv).toEqual({ A: 'config', B: 'cli', C: 'cli' });
-    expect(result.config.claudeArgs).toEqual(['--from-config', '--from-cli']);
   });
 });

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -110,57 +110,6 @@ export function loadConfig(configFile: string): AppConfig {
   }
 }
 
-export interface CliOverrides {
-  workspace?: string;
-  logDir?: string;
-  dangerouslySkipPermissions?: boolean;
-  claudeEnv?: Record<string, string>;
-  claudeArgs?: string[];
-}
-
-export interface ResolvedConfig {
-  config: AppConfig;
-  workspacePath: string;
-  logDir: string;
-  bypassPermissions: boolean;
-}
-
-export function applyCliOverrides(
-  config: AppConfig,
-  cliOpts: CliOverrides,
-  defaultConfigDir: string,
-): ResolvedConfig {
-  const workspacePath =
-    cliOpts.workspace || config.workspacePath || path.join(defaultConfigDir, 'workspace');
-
-  const logDir = cliOpts.logDir ?? path.join(defaultConfigDir, 'logs');
-
-  const bypassPermissions =
-    cliOpts.dangerouslySkipPermissions === true || config.dangerouslySkipPermissions === true;
-
-  let claudeEnv = config.claudeEnv;
-  if (cliOpts.claudeEnv && Object.keys(cliOpts.claudeEnv).length > 0) {
-    claudeEnv = { ...config.claudeEnv, ...cliOpts.claudeEnv };
-  }
-
-  let claudeArgs = config.claudeArgs;
-  if (cliOpts.claudeArgs && cliOpts.claudeArgs.length > 0) {
-    claudeArgs = [...(config.claudeArgs ?? []), ...cliOpts.claudeArgs];
-  }
-
-  return {
-    config: {
-      ...config,
-      workspacePath,
-      claudeEnv,
-      claudeArgs,
-    },
-    workspacePath,
-    logDir,
-    bypassPermissions,
-  };
-}
-
 function mergeConfig(defaults: AppConfig, partial: Partial<AppConfig>): AppConfig {
   const mcpServers: Record<string, McpServerConfig> = { ...defaults.mcpServers };
   if (partial.mcpServers) {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -127,35 +127,30 @@ export function applyCliOverrides(
   cliOpts: CommandLineOptions,
   _configDir?: string,
 ): ResolvedConfig {
-  const configDir = _configDir ? _configDir : defaultConfigDir;
+  const configDir = _configDir ?? defaultConfigDir;
+
+  console.log(cliOpts.workspace);
+  console.log(config.workspacePath);
+
   const workspacePath =
-    cliOpts.workspace || config.workspacePath || path.join(configDir, 'workspace');
+    cliOpts.workspace || config.workspacePath || path.join(defaultConfigDir, 'workspace');
 
   const logDir = cliOpts.logDir ?? path.join(configDir, 'logs');
 
   const bypassPermissions =
-    cliOpts.dangerouslySkipPermissions === true || config.dangerouslySkipPermissions === true;
+    Boolean(cliOpts.dangerouslySkipPermissions) || Boolean(config.dangerouslySkipPermissions);
 
-  let claudeEnv = config.claudeEnv;
-  if (cliOpts.claudeEnv && Object.keys(cliOpts.claudeEnv).length > 0) {
-    claudeEnv = { ...config.claudeEnv, ...cliOpts.claudeEnv };
-  }
+  const cliClaudeEnv = cliOpts.claudeEnv;
+  console.log('env:', cliClaudeEnv);
 
-  let claudeArgs = config.claudeArgs;
-  if (cliOpts.claudeArgs && cliOpts.claudeArgs.length > 0) {
-    claudeArgs = [...(config.claudeArgs ?? []), ...cliOpts.claudeArgs];
-  }
+  const claudeEnv =
+    Object.keys(cliClaudeEnv).length > 0
+      ? { ...config.claudeEnv, ...cliClaudeEnv }
+      : config.claudeEnv;
 
-  // Merge CLI env
-  const cliClaudeEnv: Record<string, string> = cliOpts.claudeEnv;
-  if (Object.keys(cliClaudeEnv).length > 0) {
-    config.claudeEnv = { ...config.claudeEnv, ...cliClaudeEnv };
-  }
-  // Merge CLI args
-  const cliClaudeArgs: string[] = cliOpts.claudeArgs;
-  if (cliClaudeArgs.length > 0) {
-    config.claudeArgs = [...(config.claudeArgs ?? []), ...cliClaudeArgs];
-  }
+  const cliClaudeArgs = cliOpts.claudeArgs;
+  const claudeArgs =
+    cliClaudeArgs.length > 0 ? [...(config.claudeArgs ?? []), ...cliClaudeArgs] : config.claudeArgs;
 
   return {
     config: {

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -146,6 +146,17 @@ export function applyCliOverrides(
     claudeArgs = [...(config.claudeArgs ?? []), ...cliOpts.claudeArgs];
   }
 
+  // Merge CLI env
+  const cliClaudeEnv: Record<string, string> = cliOpts.claudeEnv;
+  if (Object.keys(cliClaudeEnv).length > 0) {
+    config.claudeEnv = { ...config.claudeEnv, ...cliClaudeEnv };
+  }
+  // Merge CLI args
+  const cliClaudeArgs: string[] = cliOpts.claudeArgs;
+  if (cliClaudeArgs.length > 0) {
+    config.claudeArgs = [...(config.claudeArgs ?? []), ...cliClaudeArgs];
+  }
+
   return {
     config: {
       ...config,

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -129,9 +129,6 @@ export function applyCliOverrides(
 ): ResolvedConfig {
   const configDir = _configDir ?? defaultConfigDir;
 
-  console.log(cliOpts.workspace);
-  console.log(config.workspacePath);
-
   const workspacePath =
     cliOpts.workspace || config.workspacePath || path.join(defaultConfigDir, 'workspace');
 
@@ -141,7 +138,6 @@ export function applyCliOverrides(
     Boolean(cliOpts.dangerouslySkipPermissions) || Boolean(config.dangerouslySkipPermissions);
 
   const cliClaudeEnv = cliOpts.claudeEnv;
-  console.log('env:', cliClaudeEnv);
 
   const claudeEnv =
     Object.keys(cliClaudeEnv).length > 0

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -50,6 +50,12 @@ export interface AppConfig {
 
   /** Skip all permission checks (equivalent to --dangerously-skip-permissions) */
   dangerouslySkipPermissions?: boolean;
+
+  /** Additional CLI arguments appended to the Claude CLI command */
+  claudeArgs?: string[];
+
+  /** Environment variables applied when launching the Claude CLI process */
+  claudeEnv?: Record<string, string>;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {
@@ -130,5 +136,9 @@ function mergeConfig(defaults: AppConfig, partial: Partial<AppConfig>): AppConfi
     uiLanguage: partial.uiLanguage ?? defaults.uiLanguage,
     dangerouslySkipPermissions:
       partial.dangerouslySkipPermissions ?? defaults.dangerouslySkipPermissions,
+    claudeArgs: partial.claudeArgs ?? defaults.claudeArgs,
+    claudeEnv: partial.claudeEnv
+      ? { ...defaults.claudeEnv, ...partial.claudeEnv }
+      : defaults.claudeEnv,
   };
 }

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,6 +1,11 @@
 import consola from 'consola';
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
+import type { CommandLineOptions } from './utils/command-line.js';
+
+// Default base directory
+export const defaultConfigDir = path.join(os.homedir(), '.cc-spacemolt');
 
 export interface McpServerConfig {
   type: 'stdio' | 'http' | 'sse';
@@ -110,14 +115,6 @@ export function loadConfig(configFile: string): AppConfig {
   }
 }
 
-export interface CliOverrides {
-  workspace?: string;
-  logDir?: string;
-  dangerouslySkipPermissions?: boolean;
-  claudeEnv?: Record<string, string>;
-  claudeArgs?: string[];
-}
-
 export interface ResolvedConfig {
   config: AppConfig;
   workspacePath: string;
@@ -127,13 +124,14 @@ export interface ResolvedConfig {
 
 export function applyCliOverrides(
   config: AppConfig,
-  cliOpts: CliOverrides,
-  defaultConfigDir: string,
+  cliOpts: CommandLineOptions,
+  _configDir?: string,
 ): ResolvedConfig {
+  const configDir = _configDir ? _configDir : defaultConfigDir;
   const workspacePath =
-    cliOpts.workspace || config.workspacePath || path.join(defaultConfigDir, 'workspace');
+    cliOpts.workspace || config.workspacePath || path.join(configDir, 'workspace');
 
-  const logDir = cliOpts.logDir ?? path.join(defaultConfigDir, 'logs');
+  const logDir = cliOpts.logDir ?? path.join(configDir, 'logs');
 
   const bypassPermissions =
     cliOpts.dangerouslySkipPermissions === true || config.dangerouslySkipPermissions === true;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -54,9 +54,9 @@ program
     {} as Record<string, string>,
   )
   .option(
-    '--claude-arg <arg>',
-    'Additional CLI argument for Claude CLI (repeatable)',
-    (value: string, prev: string[]) => [...prev, value],
+    '--claude-args <args>',
+    'Additional args for Claude CLI, space-separated (repeatable)',
+    (value: string, prev: string[]) => [...prev, ...value.split(/\s+/).filter(Boolean)],
     [] as string[],
   );
 
@@ -148,8 +148,8 @@ if (Object.keys(cliClaudeEnv).length > 0) {
   config.claudeEnv = { ...config.claudeEnv, ...cliClaudeEnv };
 }
 
-// Merge CLI --claude-arg into config (appended after config args)
-const cliClaudeArgs: string[] = opts.claudeArg;
+// Merge CLI --claude-args into config (appended after config args)
+const cliClaudeArgs: string[] = opts.claudeArgs;
 if (cliClaudeArgs.length > 0) {
   config.claudeArgs = [...(config.claudeArgs ?? []), ...cliClaudeArgs];
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,12 +1,10 @@
-import os from 'os';
 import fs from 'fs';
-import path from 'path';
-import { program, InvalidArgumentError } from 'commander';
 import consola from 'consola';
 import ora from 'ora';
 import updateNotifier from 'update-notifier';
 import packageJson from '../../package.json' with { type: 'json' };
-import { loadConfig, applyCliOverrides } from './config.js';
+import type { AppConfig } from './config.js';
+import { loadConfig, applyCliOverrides, defaultConfigDir } from './config.js';
 import { ClaudeCliProvider } from './agent/providers/claude-cli.js';
 import { SessionManager } from './state/session-manager.js';
 import { enableDebugLog, debug } from './logger/debug-logger.js';
@@ -14,56 +12,9 @@ import { startServer } from './server.js';
 import { GameConnectionManager } from './game/game-connection-manager.js';
 import { fetchGameData } from './game/game-data-cache.js';
 import { bigLogoText } from './utils/logo.js';
+import { parseCommandLine } from './utils/command-line.js';
 
-// Default base directory
-const defaultConfigDir = path.join(os.homedir(), '.cc-spacemolt');
-
-program
-  .name('cc-spacemolt')
-  .description('Monitor tool for Claude Code CLI playing SpaceMolt')
-  .option('--config-file <path>', 'Config file path', path.join(defaultConfigDir, 'config.json'))
-  .option('--log-dir <path>', 'Log output directory')
-  .option('--workspace <path>', 'Working directory')
-  .option(
-    '--port <number>',
-    'Server port',
-    (value) => {
-      const n = parseInt(value, 10);
-      if (isNaN(n) || n < 1 || n > 65535) {
-        throw new InvalidArgumentError('Port must be an integer between 1 and 65535.');
-      }
-      return n;
-    },
-    3001,
-  )
-  .option('--host <hostname>', 'Bind hostname', 'localhost')
-  .option('--debug', 'Write debug log to debug.log')
-  .option('--dangerously-skip-permissions', 'Bypass all permission checks')
-  .option(
-    '--claude-env <KEY=VALUE>',
-    'Environment variable for Claude CLI (repeatable)',
-    (value: string, prev: Record<string, string>) => {
-      const eqIndex = value.indexOf('=');
-      if (eqIndex < 1) {
-        throw new InvalidArgumentError('Must be in KEY=VALUE format.');
-      }
-      const key = value.slice(0, eqIndex);
-      const val = value.slice(eqIndex + 1);
-      return { ...prev, [key]: val };
-    },
-    {} as Record<string, string>,
-  )
-  .option(
-    '--claude-args <args>',
-    'Additional args for Claude CLI, space-separated (repeatable)',
-    (value: string, prev: string[]) => [...prev, ...value.split(/\s+/).filter(Boolean)],
-    [] as string[],
-  );
-
-const argv = process.argv.slice(2);
-if (argv[0] === '--') argv.shift();
-program.parse(argv, { from: 'user' });
-const opts = program.opts();
+const opts = parseCommandLine(process.argv);
 const port: number = opts.port;
 const host: string = opts.host;
 
@@ -75,72 +26,33 @@ if (opts.debug) {
   consola.level = 2; // normal logs
 }
 
-// Ensure config directory exists
-fs.mkdirSync(defaultConfigDir, { recursive: true });
+async function loadAppConfig(): Promise<AppConfig> {
+  try {
+    // Ensure config directory exists
+    fs.mkdirSync(defaultConfigDir, { recursive: true });
 
-// Run setup wizard if config file doesn't exist
-if (!fs.existsSync(opts.configFile)) {
-  if (process.stdin.isTTY && process.stdout.isTTY) {
-    const { runSetupWizard } = await import('./setup.js');
-    await runSetupWizard(opts.configFile, defaultConfigDir);
-  } else {
-    // Non-interactive environment: create a default config
-    const { DEFAULT_CONFIG } = await import('./config.js');
-    fs.writeFileSync(opts.configFile, JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n', 'utf-8');
-    consola.info('No config found. Created default config at: ' + opts.configFile);
+    // Run setup wizard if config file doesn't exist
+    if (!fs.existsSync(opts.configFile)) {
+      if (process.stdin.isTTY && process.stdout.isTTY) {
+        const { runSetupWizard } = await import('./setup.js');
+        await runSetupWizard(opts.configFile, defaultConfigDir);
+      } else {
+        // Non-interactive environment: create a default config
+        const { DEFAULT_CONFIG } = await import('./config.js');
+        fs.writeFileSync(opts.configFile, JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n', 'utf-8');
+        consola.info('No config found. Created default config at: ' + opts.configFile);
+      }
+    }
+
+    return loadConfig(opts.configFile);
+  } catch (err) {
+    consola.error('Failed to load config:', err instanceof Error ? err.message : err);
+    process.exit(1);
   }
 }
 
-const loadedConfig = loadConfig(opts.configFile);
-const { config, workspacePath, logDir, bypassPermissions } = applyCliOverrides(
-  loadedConfig,
-  {
-    workspace: opts.workspace,
-    logDir: opts.logDir,
-    dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
-    claudeEnv: opts.claudeEnv,
-    claudeArgs: opts.claudeArgs,
-  },
-  defaultConfigDir,
-);
-
-// Ensure directories exist
-fs.mkdirSync(logDir, { recursive: true });
-fs.mkdirSync(workspacePath, { recursive: true });
-
-// Workaround: pre-create Claude auto-memory directory for the subprocess workspace.
-// Without this, the subprocess reads MEMORY.md concurrently with WebFetch on
-// startup; the "file not found" error cascades to WebFetch via the
-// "Sibling tool call errored" mechanism in Claude Code.
-// https://github.com/anthropics/claude-code/issues/22264
-try {
-  const projectDirName = workspacePath
-    .replace(/\\/g, '/') // normalize Windows backslashes to forward slashes
-    .replace(/:/g, '') // remove Windows drive letter colon (e.g. "C:")
-    .replace(/[/.]/g, '-'); // replace / and . with -
-  const claudeMemoryDir = path.join(os.homedir(), '.claude', 'projects', projectDirName, 'memory');
-
-  fs.mkdirSync(claudeMemoryDir, { recursive: true });
-  const claudeMemoryFile = path.join(claudeMemoryDir, 'MEMORY.md');
-  if (!fs.existsSync(claudeMemoryFile)) {
-    fs.writeFileSync(claudeMemoryFile, '', 'utf-8');
-  }
-} catch (err) {
-  debug(
-    'main',
-    'Failed to create Claude memory directory',
-    err instanceof Error ? err.message : err,
-  );
-}
-
-if (!fs.existsSync(path.join(workspacePath, '.env'))) {
-  // Create .env template
-  fs.writeFileSync(
-    path.join(workspacePath, '.env'),
-    'SPACEMOLT_USERNAME=\nSPACEMOLT_PASSWORD=\n',
-    'utf-8',
-  );
-}
+const loadedConfig = await loadAppConfig();
+const { config, workspacePath, logDir, bypassPermissions } = applyCliOverrides(loadedConfig, opts);
 
 debug('main', 'Resolved paths:', { configFile: opts.configFile, logDir, workspacePath });
 debug('main', 'Creating ClaudeCliProvider');

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import consola from 'consola';
 import ora from 'ora';
 import updateNotifier from 'update-notifier';
 import packageJson from '../../package.json' with { type: 'json' };
+
 import type { AppConfig } from './config.js';
 import { loadConfig, applyCliOverrides, defaultConfigDir } from './config.js';
 import { ClaudeCliProvider } from './agent/providers/claude-cli.js';
@@ -10,23 +11,13 @@ import { SessionManager } from './state/session-manager.js';
 import { enableDebugLog, debug } from './logger/debug-logger.js';
 import { startServer } from './server.js';
 import { GameConnectionManager } from './game/game-connection-manager.js';
+import type { CachedGameData } from './game/game-data-cache.js';
 import { fetchGameData } from './game/game-data-cache.js';
 import { bigLogoText } from './utils/logo.js';
+import type { CommandLineOptions } from './utils/command-line.js';
 import { parseCommandLine } from './utils/command-line.js';
 
-const opts = parseCommandLine(process.argv);
-const port: number = opts.port;
-const host: string = opts.host;
-
-if (opts.debug) {
-  enableDebugLog();
-  debug('main', 'CLI args:', process.argv.slice(2));
-  consola.level = 5; // verbose
-} else {
-  consola.level = 2; // normal logs
-}
-
-async function loadAppConfig(): Promise<AppConfig> {
+async function loadAppConfig(opts: CommandLineOptions): Promise<AppConfig> {
   try {
     // Ensure config directory exists
     fs.mkdirSync(defaultConfigDir, { recursive: true });
@@ -51,81 +42,95 @@ async function loadAppConfig(): Promise<AppConfig> {
   }
 }
 
-const loadedConfig = await loadAppConfig();
-const { config, workspacePath, logDir, bypassPermissions } = applyCliOverrides(loadedConfig, opts);
-
-debug('main', 'Resolved paths:', { configFile: opts.configFile, logDir, workspacePath });
-
-// Merge CLI --claude-env into config (CLI overrides config)
-const cliClaudeEnv: Record<string, string> = opts.claudeEnv;
-if (Object.keys(cliClaudeEnv).length > 0) {
-  config.claudeEnv = { ...config.claudeEnv, ...cliClaudeEnv };
+function showStartupBanner(workspacePath: string, configFilePath: string) {
+  console.log(`${bigLogoText}\n`);
+  const notifier = updateNotifier({ pkg: packageJson });
+  if (notifier.update) {
+    notifier.notify({ defer: false });
+  }
+  console.log(`Workspace: ${workspacePath}`);
+  console.log(`Config: ${configFilePath}\n`);
 }
 
-// Merge CLI --claude-args into config (appended after config args)
-const cliClaudeArgs: string[] = opts.claudeArgs;
-if (cliClaudeArgs.length > 0) {
-  config.claudeArgs = [...(config.claudeArgs ?? []), ...cliClaudeArgs];
+async function loadGameData(): Promise<CachedGameData> {
+  const gameDataSpinner = ora('Fetching game data...').start();
+  try {
+    const gameData = await fetchGameData();
+    gameDataSpinner.succeed(
+      `Game data loaded: ${gameData.systems.length} systems, ${gameData.stations.length} stations`,
+    );
+    return gameData;
+  } catch (err) {
+    gameDataSpinner.fail('Failed to fetch game data');
+    throw err;
+  }
 }
 
-debug('main', 'Creating ClaudeCliProvider');
-const provider = new ClaudeCliProvider({
-  config,
-  bypassPermissions,
-  workspacePath,
-});
+async function main() {
+  const opts = parseCommandLine(process.argv);
 
-const sessionManager = new SessionManager(provider, config.maxLogEntries, logDir);
-const gameConnectionManager = new GameConnectionManager(workspacePath);
+  if (opts.debug) {
+    enableDebugLog();
+    debug('main', 'CLI args:', process.argv.slice(2));
+    consola.level = 5; // verbose
+  } else {
+    consola.level = 2; // normal logs
+  }
 
-console.log(`${bigLogoText}\n`);
-const notifier = updateNotifier({ pkg: packageJson });
-if (notifier.update) {
-  notifier.notify({ defer: false });
-}
-console.log(`Workspace: ${workspacePath}`);
-console.log(`Config: ${opts.configFile}\n`);
-
-const gameDataSpinner = ora('Fetching game data...').start();
-let gameData;
-try {
-  gameData = await fetchGameData();
-  gameDataSpinner.succeed(
-    `Game data loaded: ${gameData.systems.length} systems, ${gameData.stations.length} stations`,
+  const loadedConfig = await loadAppConfig(opts);
+  const { config, workspacePath, logDir, bypassPermissions } = applyCliOverrides(
+    loadedConfig,
+    opts,
   );
-} catch (err) {
-  gameDataSpinner.fail('Failed to fetch game data');
-  throw err;
+
+  debug('main', 'Resolved paths:', { configFile: opts.configFile, logDir, workspacePath });
+
+  showStartupBanner(workspacePath, opts.configFile);
+
+  const provider = new ClaudeCliProvider({
+    config,
+    bypassPermissions,
+    workspacePath,
+  });
+
+  const sessionManager = new SessionManager(provider, config.maxLogEntries, logDir);
+  const gameConnectionManager = new GameConnectionManager(workspacePath);
+  const gameData = await loadGameData();
+
+  // Fetch initial game state via REST API (non-blocking)
+  gameConnectionManager.fetchInitialState().catch((err) => {
+    debug('main', `Initial game state fetch failed: ${err}`);
+  });
+
+  startServer({
+    port: opts.port,
+    host: opts.host,
+    sessionManager,
+    gameConnectionManager,
+    initialPrompt: config.initialPrompt,
+    gameData,
+    logDir,
+  });
+
+  // Graceful shutdown
+  const shutdown = () => {
+    gameConnectionManager.cleanup();
+    sessionManager.abort();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', () => {
+    debug('main', 'SIGINT received, shutting down');
+    shutdown();
+  });
+
+  process.on('SIGTERM', () => {
+    debug('main', 'SIGTERM received, shutting down');
+    shutdown();
+  });
 }
 
-// Fetch initial game state via REST API (non-blocking)
-gameConnectionManager.fetchInitialState().catch((err) => {
-  debug('main', `Initial game state fetch failed: ${err}`);
-});
-
-startServer({
-  port,
-  host,
-  sessionManager,
-  gameConnectionManager,
-  initialPrompt: config.initialPrompt,
-  gameData,
-  logDir,
-});
-
-// Graceful shutdown
-const shutdown = () => {
-  gameConnectionManager.cleanup();
-  sessionManager.abort();
-  process.exit(0);
-};
-
-process.on('SIGINT', () => {
-  debug('main', 'SIGINT received, shutting down');
-  shutdown();
-});
-
-process.on('SIGTERM', () => {
-  debug('main', 'SIGTERM received, shutting down');
-  shutdown();
+main().catch((err) => {
+  consola.error('Fatal error:', err instanceof Error ? err.message : err);
+  process.exit(1);
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -52,6 +52,12 @@ program
       return { ...prev, [key]: val };
     },
     {} as Record<string, string>,
+  )
+  .option(
+    '--claude-arg <arg>',
+    'Additional CLI argument for Claude CLI (repeatable)',
+    (value: string, prev: string[]) => [...prev, value],
+    [] as string[],
   );
 
 const argv = process.argv.slice(2);
@@ -140,6 +146,12 @@ const bypassPermissions =
 const cliClaudeEnv: Record<string, string> = opts.claudeEnv;
 if (Object.keys(cliClaudeEnv).length > 0) {
   config.claudeEnv = { ...config.claudeEnv, ...cliClaudeEnv };
+}
+
+// Merge CLI --claude-arg into config (appended after config args)
+const cliClaudeArgs: string[] = opts.claudeArg;
+if (cliClaudeArgs.length > 0) {
+  config.claudeArgs = [...(config.claudeArgs ?? []), ...cliClaudeArgs];
 }
 
 debug('main', 'Creating ClaudeCliProvider');

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,7 +6,7 @@ import consola from 'consola';
 import ora from 'ora';
 import updateNotifier from 'update-notifier';
 import packageJson from '../../package.json' with { type: 'json' };
-import { loadConfig, applyCliOverrides } from './config.js';
+import { loadConfig } from './config.js';
 import { ClaudeCliProvider } from './agent/providers/claude-cli.js';
 import { SessionManager } from './state/session-manager.js';
 import { enableDebugLog, debug } from './logger/debug-logger.js';
@@ -91,18 +91,13 @@ if (!fs.existsSync(opts.configFile)) {
   }
 }
 
-const loadedConfig = loadConfig(opts.configFile);
-const { config, workspacePath, logDir, bypassPermissions } = applyCliOverrides(
-  loadedConfig,
-  {
-    workspace: opts.workspace,
-    logDir: opts.logDir,
-    dangerouslySkipPermissions: opts.dangerouslySkipPermissions,
-    claudeEnv: opts.claudeEnv,
-    claudeArgs: opts.claudeArgs,
-  },
-  defaultConfigDir,
-);
+const config = loadConfig(opts.configFile);
+
+// Resolve paths: CLI > config > default
+const logDir = opts.logDir ?? path.join(defaultConfigDir, 'logs');
+const workspacePath =
+  opts.workspace || config.workspacePath || path.join(defaultConfigDir, 'workspace');
+config.workspacePath = workspacePath;
 
 // Ensure directories exist
 fs.mkdirSync(logDir, { recursive: true });
@@ -143,6 +138,22 @@ if (!fs.existsSync(path.join(workspacePath, '.env'))) {
 }
 
 debug('main', 'Resolved paths:', { configFile: opts.configFile, logDir, workspacePath });
+
+const bypassPermissions =
+  opts.dangerouslySkipPermissions || config.dangerouslySkipPermissions === true;
+
+// Merge CLI --claude-env into config (CLI overrides config)
+const cliClaudeEnv: Record<string, string> = opts.claudeEnv;
+if (Object.keys(cliClaudeEnv).length > 0) {
+  config.claudeEnv = { ...config.claudeEnv, ...cliClaudeEnv };
+}
+
+// Merge CLI --claude-args into config (appended after config args)
+const cliClaudeArgs: string[] = opts.claudeArgs;
+if (cliClaudeArgs.length > 0) {
+  config.claudeArgs = [...(config.claudeArgs ?? []), ...cliClaudeArgs];
+}
+
 debug('main', 'Creating ClaudeCliProvider');
 const provider = new ClaudeCliProvider({
   config,

--- a/backend/src/utils/command-line.ts
+++ b/backend/src/utils/command-line.ts
@@ -1,0 +1,57 @@
+import { Command, InvalidArgumentError } from '@commander-js/extra-typings';
+import path from 'path';
+import { defaultConfigDir } from '../config.js';
+
+function createCommand() {
+  return new Command()
+    .name('cc-spacemolt')
+    .description('Monitor tool for Claude Code CLI playing SpaceMolt')
+    .option('--config-file <path>', 'Config file path', path.join(defaultConfigDir, 'config.json'))
+    .option('--log-dir <path>', 'Log output directory')
+    .option('--workspace <path>', 'Working directory')
+    .option(
+      '--port <number>',
+      'Server port',
+      (value) => {
+        const n = parseInt(value, 10);
+        if (isNaN(n) || n < 1 || n > 65535) {
+          throw new InvalidArgumentError('Port must be an integer between 1 and 65535.');
+        }
+        return n;
+      },
+      3001,
+    )
+    .option('--host <hostname>', 'Bind hostname', 'localhost')
+    .option('--debug', 'Write debug log to debug.log')
+    .option('--dangerously-skip-permissions', 'Bypass all permission checks')
+    .option(
+      '--claude-env <KEY=VALUE>',
+      'Environment variable for Claude CLI (repeatable)',
+      (value: string, prev: Record<string, string>) => {
+        const eqIndex = value.indexOf('=');
+        if (eqIndex < 1) {
+          throw new InvalidArgumentError('Must be in KEY=VALUE format.');
+        }
+        const key = value.slice(0, eqIndex);
+        const val = value.slice(eqIndex + 1);
+        return { ...prev, [key]: val };
+      },
+      {} as Record<string, string>,
+    )
+    .option(
+      '--claude-args <args>',
+      'Additional args for Claude CLI, space-separated (repeatable)',
+      (value: string, prev: string[]) => [...prev, ...value.split(/\s+/).filter(Boolean)],
+      [] as string[],
+    );
+}
+
+export function parseCommandLine(argv: string[]) {
+  const command = createCommand();
+  const args = argv.slice(2);
+  if (args[0] === '--') args.shift();
+  command.parse(args, { from: 'user' });
+  return command.opts() as CommandLineOptions;
+}
+
+export type CommandLineOptions = ReturnType<ReturnType<typeof createCommand>['opts']>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -815,6 +815,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -832,6 +833,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -849,6 +851,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -866,6 +869,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -883,6 +887,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -900,6 +905,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -917,6 +923,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -934,6 +941,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -951,6 +959,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -968,6 +977,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -985,6 +995,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1002,6 +1013,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1019,6 +1031,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1036,6 +1049,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1053,6 +1067,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1070,6 +1085,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1087,6 +1103,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1104,6 +1121,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1121,6 +1139,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1138,6 +1157,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1155,6 +1175,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1172,6 +1193,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1189,6 +1211,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1206,6 +1229,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1223,6 +1247,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1240,6 +1265,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5925,6 +5951,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5946,6 +5973,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5967,6 +5995,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5988,6 +6017,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6009,6 +6039,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6030,6 +6061,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6051,6 +6083,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6072,6 +6105,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6093,6 +6127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6114,6 +6149,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6135,6 +6171,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@cc-spacemolt/shared": "*",
+        "@commander-js/extra-typings": "^14.0.0",
         "@hono/node-server": "^1.14.0",
         "@inquirer/prompts": "^8.2.1",
         "commander": "^14.0.3",
@@ -687,6 +688,15 @@
       "resolved": "shared",
       "link": true
     },
+    "node_modules/@commander-js/extra-typings": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@commander-js/extra-typings/-/extra-typings-14.0.0.tgz",
+      "integrity": "sha512-hIn0ncNaJRLkZrxBIp5AsW/eXEHNKYQBh0aPdoUqNgD+Io3NIykQqpKFyKcuasZhicGaEZJX/JBSIkZ4e5x8Dg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "commander": "~14.0.0"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -815,7 +825,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -833,7 +842,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -851,7 +859,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -869,7 +876,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -887,7 +893,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -905,7 +910,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -923,7 +927,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -941,7 +944,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -959,7 +961,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,7 +978,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -995,7 +995,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1013,7 +1012,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1031,7 +1029,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1049,7 +1046,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1067,7 +1063,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1085,7 +1080,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1103,7 +1097,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1121,7 +1114,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1139,7 +1131,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1157,7 +1148,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1175,7 +1165,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1193,7 +1182,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1211,7 +1199,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1229,7 +1216,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1247,7 +1233,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1265,7 +1250,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5951,7 +5935,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5973,7 +5956,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5995,7 +5977,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6017,7 +5998,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6039,7 +6019,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6061,7 +6040,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6083,7 +6061,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6105,7 +6082,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6127,7 +6103,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6149,7 +6124,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6171,7 +6145,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },


### PR DESCRIPTION
## Summary

Add support for passing custom arguments and environment variables to the Claude Code through both CLI options and config file. 

## Changes

- Added `--claude-env <KEY=VALUE>` (repeatable) and `--claude-arg <arg>` (repeatable) options to pass environment variables and arguments to Claude CLI
- Added `claudeArgs` (string[]) and `claudeEnv` (Record<string, string>) fields to config
- Added comprehensive unit tests for config loading with `claudeArgs` and `claudeEnv`
