### PR TITLE
Customize name/avater image for agent and user

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ cc-spacemolt/
     utils/                   — helpers (truncate, format, env, context-window)
   frontend/src/
     hooks/                   — useWebSocket (all state management), useMapData, useStickToBottom
+    contexts/                — React Contexts: AgentContext, GameContext, ConfigContext
     components/              — Layout, 3 panels (ShipPanel, ClaudePanel, EventsPanel), StarMap, etc.
     components/messages/     — per-message-type rendering (Text, Thinking, ToolCall, SpacemoltTool, etc.)
     components/common/       — shared UI (GaugeBar, Chip, Icons, MarkdownContent)
@@ -121,7 +122,7 @@ cc-spacemolt/
 - **Memory management**: Drop old entries from memory when count exceeds `maxLogEntries` (default 1000). All entries are still written to log files.
 - **3-panel dashboard**: 12-column grid — Ship (col-span-3) / Claude Code (col-span-5) / Events (col-span-4). Mobile uses tab switching. Dark theme (zinc color palette).
 - **Canvas star map**: Rendered in a `requestAnimationFrame` loop. LERP-interpolated camera movement, current-location highlight, movement animation, drag and zoom support.
-- **Single-hook state management**: `useWebSocket` manages all application state. No external state library; state is passed down via props.
+- **State management**: `useWebSocket` manages all application state. `App` distributes it into three React Contexts — `AgentContext` (entries, status, connected, callbacks), `GameContext` (gameState, gameStatus, events, travelHistory), `ConfigContext` (agentAvatarUrl, userName, userAvatarUrl, initialPrompt). Components consume contexts directly via `useAgent()`, `useGame()`, `useConfig()`. No external state library.
 - **shared type composite reference**: `shared/tsconfig.json` uses `composite: true`. After adding types, regenerate declaration files with `npx tsc --build shared/tsconfig.json`.
 
 ### CLI Options

--- a/README-ja.md
+++ b/README-ja.md
@@ -109,8 +109,15 @@ cc-spacemolt [options]
   "dangerouslySkipPermissions": false, // 全ての権限確認をスキップ（使用する場合は十分に注意してください）
   "claudeArgs": ["--verbose"], // Claude CLI コマンドに追加される引数
   "claudeEnv": { "MY_VAR": "value" }, // Claude CLI 起動時に適用される環境変数
+  "userName": "Your Name", // チャット UI に表示される自分の名前
+  "userAvatarPath": "avatar.png", // 自分のアバター画像のパス（ワークスペースからの相対パスまたは絶対パス）
 }
 ```
+
+### エージェントのアバター
+
+- エージェントの名前は、.env ファイルの `SPACEMOLT_USERNAME` から取得されます。
+- エージェントのアバター画像は、workspace内に `avatar.png` があれば自動で使用します。
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -109,8 +109,15 @@ Configure behavior via `~/.cc-spacemolt/config.json` (or `data/config.json` duri
   "dangerouslySkipPermissions": false, // Bypass all permission checks (use with caution)
   "claudeArgs": ["--verbose"], // Additional CLI arguments appended to the Claude CLI command
   "claudeEnv": { "MY_VAR": "value" }, // Environment variables applied when launching Claude CLI
+  "userName": "Your Name", // Display name shown in the chat UI for your messages
+  "userAvatarPath": "avatar.png", // Path to your avatar image (relative to workspace, or absolute)
 }
 ```
+
+### Agent Avatar
+
+- The agent's name is taken from the `SPACEMOLT_USERNAME` variable in the .env file.
+- If there is an `avatar.png` in the workspace, it will be automatically used as the agent's avatar image.
 
 ## Development
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -154,12 +154,18 @@ export function applyCliOverrides(
   const claudeArgs =
     cliClaudeArgs.length > 0 ? [...(config.claudeArgs ?? []), ...cliClaudeArgs] : config.claudeArgs;
 
+  // Resolve userAvatarPath relative to workspacePath when it's a relative path
+  const userAvatarPath = config.userAvatarPath
+    ? path.resolve(workspacePath, config.userAvatarPath)
+    : undefined;
+
   return {
     config: {
       ...config,
       workspacePath,
       claudeEnv,
       claudeArgs,
+      userAvatarPath,
     },
     workspacePath,
     logDir,

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -61,6 +61,12 @@ export interface AppConfig {
 
   /** Environment variables applied when launching the Claude CLI process */
   claudeEnv?: Record<string, string>;
+
+  /** Display name for the human operator (shown in UserMessage) */
+  userName?: string;
+
+  /** Path to an avatar image for the human operator (shown in UserMessage) */
+  userAvatarPath?: string;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {
@@ -191,5 +197,7 @@ function mergeConfig(defaults: AppConfig, partial: Partial<AppConfig>): AppConfi
     claudeEnv: partial.claudeEnv
       ? { ...defaults.claudeEnv, ...partial.claudeEnv }
       : defaults.claudeEnv,
+    userName: partial.userName ?? defaults.userName,
+    userAvatarPath: partial.userAvatarPath ?? defaults.userAvatarPath,
   };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -128,6 +128,9 @@ async function main() {
     initialPrompt: config.initialPrompt,
     gameData,
     logDir,
+    workspacePath,
+    userName: config.userName,
+    userAvatarPath: config.userAvatarPath,
   });
 
   // Graceful shutdown

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,51 @@
 import { useWebSocket } from './hooks/useWebSocket';
 import { Layout } from './components/Layout';
+import { AgentContext } from './contexts/AgentContext';
+import { GameContext } from './contexts/GameContext';
+import { ConfigContext } from './contexts/ConfigContext';
 
 export function App() {
-  const ws = useWebSocket();
+  const {
+    entries,
+    sessionMeta,
+    status,
+    connected,
+    gameState,
+    gameStatus,
+    events,
+    travelHistory,
+    initialPrompt,
+    agentAvatarUrl,
+    userName,
+    userAvatarUrl,
+    startAgent,
+    sendMessage,
+    interrupt,
+    abort,
+    resetSession,
+    selectSession,
+  } = useWebSocket();
 
-  return <Layout {...ws} />;
+  return (
+    <AgentContext.Provider
+      value={{
+        entries,
+        sessionMeta,
+        status,
+        connected,
+        startAgent,
+        sendMessage,
+        interrupt,
+        abort,
+        resetSession,
+        selectSession,
+      }}
+    >
+      <GameContext.Provider value={{ gameState, gameStatus, events, travelHistory }}>
+        <ConfigContext.Provider value={{ agentAvatarUrl, userName, userAvatarUrl, initialPrompt }}>
+          <Layout />
+        </ConfigContext.Provider>
+      </GameContext.Provider>
+    </AgentContext.Provider>
+  );
 }

--- a/frontend/src/components/ClaudePanel.tsx
+++ b/frontend/src/components/ClaudePanel.tsx
@@ -41,6 +41,10 @@ interface ClaudePanelProps {
   status: AgentStatus;
   connected: boolean;
   initialPrompt: string;
+  agentName?: string;
+  agentAvatarUrl?: string;
+  userName?: string;
+  userAvatarUrl?: string;
   startAgent: (instructions?: string) => void;
   sendMessage: (text: string) => void;
   interrupt: () => void;
@@ -54,6 +58,10 @@ export function ClaudePanel({
   status,
   connected,
   initialPrompt,
+  agentName,
+  agentAvatarUrl,
+  userName,
+  userAvatarUrl,
   startAgent,
   sendMessage,
   interrupt,
@@ -219,6 +227,10 @@ export function ClaudePanel({
                 entry={entry}
                 toolResultMap={toolResultMap}
                 isFirstSystem={entry.id === firstSystemId}
+                agentName={agentName}
+                agentAvatarUrl={agentAvatarUrl}
+                userName={userName}
+                userAvatarUrl={userAvatarUrl}
               />
             ));
           })()}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,13 +1,5 @@
 import { useState } from 'react';
-import type {
-  ParsedEntry,
-  SessionMeta,
-  AgentStatus,
-  GameState,
-  GameEvent,
-  GameConnectionStatus,
-  TravelHistoryEntry,
-} from '@cc-spacemolt/shared';
+import { useGame } from '../contexts/GameContext';
 import { TopBar } from './TopBar';
 import { MobileTabBar, type TabKey } from './MobileTabBar';
 import { ShipPanel } from './ShipPanel';
@@ -15,51 +7,14 @@ import { ShipDetailModal } from './ShipDetailModal';
 import { ClaudePanel } from './ClaudePanel';
 import { EventsPanel } from './EventsPanel';
 
-interface LayoutProps {
-  entries: ParsedEntry[];
-  sessionMeta: SessionMeta | null;
-  status: AgentStatus;
-  connected: boolean;
-  gameState: GameState | null;
-  gameStatus: { status: GameConnectionStatus; message?: string };
-  events: GameEvent[];
-  travelHistory: TravelHistoryEntry[];
-  initialPrompt: string;
-  agentAvatarUrl?: string;
-  userName?: string;
-  userAvatarUrl?: string;
-  startAgent: (instructions?: string) => void;
-  sendMessage: (text: string) => void;
-  interrupt: () => void;
-  resetSession: () => void;
-  selectSession: (sessionId: string) => void;
-}
-
-export function Layout({
-  entries,
-  sessionMeta,
-  status,
-  connected,
-  gameState,
-  gameStatus,
-  events,
-  travelHistory,
-  initialPrompt,
-  agentAvatarUrl,
-  userName,
-  userAvatarUrl,
-  startAgent,
-  sendMessage,
-  interrupt,
-  resetSession,
-  selectSession,
-}: LayoutProps) {
+export function Layout() {
+  const { gameState, events, travelHistory } = useGame();
   const [mobileTab, setMobileTab] = useState<TabKey>('claude');
   const [showDetail, setShowDetail] = useState(false);
 
   return (
     <div className="h-dvh w-screen flex flex-col overflow-hidden">
-      <TopBar connected={connected} gameStatus={gameStatus} gameState={gameState} />
+      <TopBar />
       <MobileTabBar active={mobileTab} onChange={setMobileTab} />
 
       <div className="flex-1 overflow-hidden">
@@ -79,22 +34,7 @@ export function Layout({
             )}
           </div>
           <div className="col-span-5 bg-zinc-900 overflow-hidden">
-            <ClaudePanel
-              entries={entries}
-              sessionMeta={sessionMeta}
-              status={status}
-              connected={connected}
-              initialPrompt={initialPrompt}
-              agentName={gameState?.player.username}
-              agentAvatarUrl={agentAvatarUrl}
-              userName={userName}
-              userAvatarUrl={userAvatarUrl}
-              startAgent={startAgent}
-              sendMessage={sendMessage}
-              interrupt={interrupt}
-              resetSession={resetSession}
-              selectSession={selectSession}
-            />
+            <ClaudePanel />
           </div>
           <div className="col-span-4 bg-zinc-900 overflow-hidden">
             <EventsPanel events={events} />
@@ -115,24 +55,7 @@ export function Layout({
                 Waiting for game data...
               </div>
             ))}
-          {mobileTab === 'claude' && (
-            <ClaudePanel
-              entries={entries}
-              sessionMeta={sessionMeta}
-              status={status}
-              connected={connected}
-              initialPrompt={initialPrompt}
-              agentName={gameState?.player.username}
-              agentAvatarUrl={agentAvatarUrl}
-              userName={userName}
-              userAvatarUrl={userAvatarUrl}
-              startAgent={startAgent}
-              sendMessage={sendMessage}
-              interrupt={interrupt}
-              resetSession={resetSession}
-              selectSession={selectSession}
-            />
-          )}
+          {mobileTab === 'claude' && <ClaudePanel />}
           {mobileTab === 'events' && <EventsPanel events={events} />}
         </div>
       </div>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -25,6 +25,9 @@ interface LayoutProps {
   events: GameEvent[];
   travelHistory: TravelHistoryEntry[];
   initialPrompt: string;
+  agentAvatarUrl?: string;
+  userName?: string;
+  userAvatarUrl?: string;
   startAgent: (instructions?: string) => void;
   sendMessage: (text: string) => void;
   interrupt: () => void;
@@ -42,6 +45,9 @@ export function Layout({
   events,
   travelHistory,
   initialPrompt,
+  agentAvatarUrl,
+  userName,
+  userAvatarUrl,
   startAgent,
   sendMessage,
   interrupt,
@@ -79,6 +85,10 @@ export function Layout({
               status={status}
               connected={connected}
               initialPrompt={initialPrompt}
+              agentName={gameState?.player.username}
+              agentAvatarUrl={agentAvatarUrl}
+              userName={userName}
+              userAvatarUrl={userAvatarUrl}
               startAgent={startAgent}
               sendMessage={sendMessage}
               interrupt={interrupt}
@@ -112,6 +122,10 @@ export function Layout({
               status={status}
               connected={connected}
               initialPrompt={initialPrompt}
+              agentName={gameState?.player.username}
+              agentAvatarUrl={agentAvatarUrl}
+              userName={userName}
+              userAvatarUrl={userAvatarUrl}
               startAgent={startAgent}
               sendMessage={sendMessage}
               interrupt={interrupt}

--- a/frontend/src/components/ShipPanel.tsx
+++ b/frontend/src/components/ShipPanel.tsx
@@ -6,6 +6,8 @@ import { PanelHeader } from './common/PanelHeader';
 import { PanelHeaderButton } from './common/PanelHeaderButton';
 import { StarMap } from './StarMap';
 import { useMapData, resolveSystem } from '../hooks/useMapData';
+import { useConfig } from '../contexts/ConfigContext';
+import { Avatar } from './common/Avatar';
 
 interface ShipPanelProps {
   state: GameState;
@@ -29,6 +31,7 @@ export function ShipPanel({ state, travelHistory, onOpenDetail }: ShipPanelProps
   const { data: mapData } = useMapData();
   const currentSystem = mapData ? resolveSystem(mapData, player.current_system) : null;
   const systemDisplayName = currentSystem?.name ?? player.current_system;
+  const { agentAvatarUrl } = useConfig();
 
   return (
     <div className="flex flex-col h-full">
@@ -39,7 +42,7 @@ export function ShipPanel({ state, travelHistory, onOpenDetail }: ShipPanelProps
         right={
           <>
             {in_combat && (
-              <span className="text-2xs px-1.5 py-0.5 rounded-full bg-red-500/20 text-red-400 border border-red-500/30 animate-pulse font-bold tracking-wider">
+              <span className="text-2xs px-5 py-0.5 rounded-full bg-red-500/20 text-red-400 border border-red-500/30 animate-pulse font-bold tracking-wider">
                 COMBAT
               </span>
             )}
@@ -51,9 +54,13 @@ export function ShipPanel({ state, travelHistory, onOpenDetail }: ShipPanelProps
       />
       <div className="flex-1 overflow-y-auto p-3 space-y-3 custom-scrollbar min-h-0">
         <div className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg bg-zinc-800/40 border border-zinc-800">
-          <div className="w-6 h-6 rounded-full bg-gradient-to-br from-violet-500 to-cyan-500 flex items-center justify-center text-xs font-bold text-white shrink-0">
-            {player.username[0]}
-          </div>
+          <Avatar
+            url={agentAvatarUrl}
+            initial="C"
+            gradientClasses="from-orange-400 to-amber-600"
+            size={42}
+          />
+
           <div className="flex-1 min-w-0">
             <div className="text-base text-zinc-200 truncate">{player.username}</div>
             <div className="flex items-center gap-1 text-xs truncate">

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,12 +1,8 @@
 import { useState, useEffect } from 'react';
-import type { GameState, GameConnectionStatus } from '@cc-spacemolt/shared';
+import type { GameConnectionStatus } from '@cc-spacemolt/shared';
+import { useAgent } from '../contexts/AgentContext';
+import { useGame } from '../contexts/GameContext';
 import { getVersion } from '../utils/version';
-
-interface TopBarProps {
-  connected: boolean;
-  gameStatus: { status: GameConnectionStatus; message?: string };
-  gameState: GameState | null;
-}
 
 const gameIndicator: Record<GameConnectionStatus, { dot: string; text: string; label: string }> = {
   connecting: {
@@ -31,7 +27,9 @@ const gameIndicator: Record<GameConnectionStatus, { dot: string; text: string; l
   },
 };
 
-export function TopBar({ connected, gameStatus, gameState }: TopBarProps) {
+export function TopBar() {
+  const { connected } = useAgent();
+  const { gameStatus, gameState } = useGame();
   const [time, setTime] = useState(new Date());
 
   useEffect(() => {

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+
+interface AvatarProps {
+  /** URL of the avatar image. Falls back to initial circle when undefined or on load error. */
+  url?: string;
+  /** Fallback letter shown in the circle when no image is available. */
+  initial: string;
+  /** Tailwind gradient classes for the fallback circle (e.g. "from-orange-400 to-amber-600"). */
+  gradientClasses: string;
+}
+
+export function Avatar({ url, initial, gradientClasses }: AvatarProps) {
+  const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [url]);
+
+  if (url && !imgError) {
+    return (
+      <img
+        src={url}
+        alt=""
+        className="w-3 h-3 rounded-full object-cover shrink-0"
+        onError={() => setImgError(true)}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`w-3 h-3 rounded-full bg-gradient-to-br ${gradientClasses} flex items-center justify-center shrink-0`}
+    >
+      <span className="text-2xs font-bold text-white">{initial}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -1,19 +1,22 @@
 import { useState, useEffect } from 'react';
 
 interface AvatarProps {
-  /** URL of the avatar image. Falls back to initial circle when undefined or on load error. */
+  // URL of the avatar image. Falls back to initial circle when undefined or on load error.
   url?: string;
-  /** Fallback letter shown in the circle when no image is available. */
+  // Fallback letter shown in the circle when no image is available.
   initial: string;
-  /** Tailwind gradient classes for the fallback circle (e.g. "from-orange-400 to-amber-600"). */
+  // Tailwind gradient classes for the fallback circle
   gradientClasses: string;
+  // Size of the avatar
+  size?: number;
 }
 
-export function Avatar({ url, initial, gradientClasses }: AvatarProps) {
+export function Avatar({ url, initial, gradientClasses, size = 16 }: AvatarProps) {
   const [imgError, setImgError] = useState(false);
+  const sizeStyle = { width: `${size}px`, height: `${size}px` };
 
   useEffect(() => {
-    setImgError(false);
+    setImgError(url ? false : true);
   }, [url]);
 
   if (url && !imgError) {
@@ -21,7 +24,8 @@ export function Avatar({ url, initial, gradientClasses }: AvatarProps) {
       <img
         src={url}
         alt=""
-        className="w-3 h-3 rounded-full object-cover shrink-0"
+        className="rounded-full object-cover shrink-0"
+        style={sizeStyle}
         onError={() => setImgError(true)}
       />
     );
@@ -29,7 +33,8 @@ export function Avatar({ url, initial, gradientClasses }: AvatarProps) {
 
   return (
     <div
-      className={`w-3 h-3 rounded-full bg-gradient-to-br ${gradientClasses} flex items-center justify-center shrink-0`}
+      className={`rounded-full bg-gradient-to-br ${gradientClasses} flex items-center justify-center shrink-0`}
+      style={sizeStyle}
     >
       <span className="text-2xs font-bold text-white">{initial}</span>
     </div>

--- a/frontend/src/components/messages/EntryRenderer.tsx
+++ b/frontend/src/components/messages/EntryRenderer.tsx
@@ -11,23 +11,17 @@ export function EntryRenderer({
   toolResultMap,
   isFirstSystem,
   agentName,
-  agentAvatarUrl,
-  userName,
-  userAvatarUrl,
 }: {
   entry: ParsedEntry;
   toolResultMap: Map<string, ToolResultEntry>;
   isFirstSystem?: boolean;
   agentName?: string;
-  agentAvatarUrl?: string;
-  userName?: string;
-  userAvatarUrl?: string;
 }) {
   switch (entry.kind) {
     case 'system':
       return isFirstSystem ? <SystemMessage entry={entry} /> : null;
     case 'text':
-      return <TextMessage entry={entry} name={agentName} avatarUrl={agentAvatarUrl} />;
+      return <TextMessage entry={entry} name={agentName} />;
     case 'thinking':
       return <ThinkingBlock entry={entry} />;
     case 'tool_call':
@@ -35,7 +29,7 @@ export function EntryRenderer({
     case 'tool_result':
       return null;
     case 'user_message':
-      return <UserMessage entry={entry} name={userName} avatarUrl={userAvatarUrl} />;
+      return <UserMessage entry={entry} />;
     case 'result':
       return <ResultMessage entry={entry} />;
   }

--- a/frontend/src/components/messages/EntryRenderer.tsx
+++ b/frontend/src/components/messages/EntryRenderer.tsx
@@ -10,16 +10,24 @@ export function EntryRenderer({
   entry,
   toolResultMap,
   isFirstSystem,
+  agentName,
+  agentAvatarUrl,
+  userName,
+  userAvatarUrl,
 }: {
   entry: ParsedEntry;
   toolResultMap: Map<string, ToolResultEntry>;
   isFirstSystem?: boolean;
+  agentName?: string;
+  agentAvatarUrl?: string;
+  userName?: string;
+  userAvatarUrl?: string;
 }) {
   switch (entry.kind) {
     case 'system':
       return isFirstSystem ? <SystemMessage entry={entry} /> : null;
     case 'text':
-      return <TextMessage entry={entry} />;
+      return <TextMessage entry={entry} name={agentName} avatarUrl={agentAvatarUrl} />;
     case 'thinking':
       return <ThinkingBlock entry={entry} />;
     case 'tool_call':
@@ -27,7 +35,7 @@ export function EntryRenderer({
     case 'tool_result':
       return null;
     case 'user_message':
-      return <UserMessage entry={entry} />;
+      return <UserMessage entry={entry} name={userName} avatarUrl={userAvatarUrl} />;
     case 'result':
       return <ResultMessage entry={entry} />;
   }

--- a/frontend/src/components/messages/TextMessage.tsx
+++ b/frontend/src/components/messages/TextMessage.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
 import type { TextEntry } from '@cc-spacemolt/shared';
 import { MarkdownContent } from '../common/MarkdownContent';
+import { Avatar } from '../common/Avatar';
 import { MessageHeader } from './MessageHeader';
 
 export function TextMessage({
@@ -12,21 +12,9 @@ export function TextMessage({
   name?: string;
   avatarUrl?: string;
 }) {
-  const [imgError, setImgError] = useState(false);
-
-  const icon =
-    avatarUrl && !imgError ? (
-      <img
-        src={avatarUrl}
-        alt=""
-        className="w-3 h-3 rounded-full object-cover shrink-0"
-        onError={() => setImgError(true)}
-      />
-    ) : (
-      <div className="w-3 h-3 rounded-full bg-gradient-to-br from-orange-400 to-amber-600 flex items-center justify-center shrink-0">
-        <span className="text-2xs font-bold text-white">C</span>
-      </div>
-    );
+  const icon = (
+    <Avatar url={avatarUrl} initial="C" gradientClasses="from-orange-400 to-amber-600" />
+  );
 
   return (
     <div>

--- a/frontend/src/components/messages/TextMessage.tsx
+++ b/frontend/src/components/messages/TextMessage.tsx
@@ -8,7 +8,11 @@ export function TextMessage({ entry, name }: { entry: TextEntry; name?: string }
   const { agentAvatarUrl } = useConfig();
 
   const icon = (
-    <Avatar url={agentAvatarUrl} initial="C" gradientClasses="from-orange-400 to-amber-600" />
+    <Avatar
+      url={agentAvatarUrl}
+      initial={name ? name[0] : 'A'}
+      gradientClasses="from-orange-400 to-amber-600"
+    />
   );
 
   return (

--- a/frontend/src/components/messages/TextMessage.tsx
+++ b/frontend/src/components/messages/TextMessage.tsx
@@ -1,19 +1,36 @@
+import { useState } from 'react';
 import type { TextEntry } from '@cc-spacemolt/shared';
 import { MarkdownContent } from '../common/MarkdownContent';
 import { MessageHeader } from './MessageHeader';
 
-export function TextMessage({ entry }: { entry: TextEntry }) {
+export function TextMessage({
+  entry,
+  name,
+  avatarUrl,
+}: {
+  entry: TextEntry;
+  name?: string;
+  avatarUrl?: string;
+}) {
+  const [imgError, setImgError] = useState(false);
+
+  const icon =
+    avatarUrl && !imgError ? (
+      <img
+        src={avatarUrl}
+        alt=""
+        className="w-3 h-3 rounded-full object-cover shrink-0"
+        onError={() => setImgError(true)}
+      />
+    ) : (
+      <div className="w-3 h-3 rounded-full bg-gradient-to-br from-orange-400 to-amber-600 flex items-center justify-center shrink-0">
+        <span className="text-2xs font-bold text-white">C</span>
+      </div>
+    );
+
   return (
     <div>
-      <MessageHeader
-        icon={
-          <div className="w-3 h-3 rounded-full bg-gradient-to-br from-orange-400 to-amber-600 flex items-center justify-center shrink-0">
-            <span className="text-2xs font-bold text-white">C</span>
-          </div>
-        }
-        label="Agent"
-        timestamp={entry.timestamp}
-      >
+      <MessageHeader icon={icon} label={name ?? 'Agent'} timestamp={entry.timestamp}>
         {entry.isStreaming && (
           <div className="flex gap-0.5 ml-1">
             {[0, 150, 300].map((d) => (

--- a/frontend/src/components/messages/TextMessage.tsx
+++ b/frontend/src/components/messages/TextMessage.tsx
@@ -1,19 +1,14 @@
 import type { TextEntry } from '@cc-spacemolt/shared';
+import { useConfig } from '../../contexts/ConfigContext';
 import { MarkdownContent } from '../common/MarkdownContent';
 import { Avatar } from '../common/Avatar';
 import { MessageHeader } from './MessageHeader';
 
-export function TextMessage({
-  entry,
-  name,
-  avatarUrl,
-}: {
-  entry: TextEntry;
-  name?: string;
-  avatarUrl?: string;
-}) {
+export function TextMessage({ entry, name }: { entry: TextEntry; name?: string }) {
+  const { agentAvatarUrl } = useConfig();
+
   const icon = (
-    <Avatar url={avatarUrl} initial="C" gradientClasses="from-orange-400 to-amber-600" />
+    <Avatar url={agentAvatarUrl} initial="C" gradientClasses="from-orange-400 to-amber-600" />
   );
 
   return (

--- a/frontend/src/components/messages/UserMessage.tsx
+++ b/frontend/src/components/messages/UserMessage.tsx
@@ -1,16 +1,39 @@
+import { useState } from 'react';
 import type { UserMessageEntry } from '@cc-spacemolt/shared';
 import { MessageHeader } from './MessageHeader';
 
-export function UserMessage({ entry }: { entry: UserMessageEntry }) {
+export function UserMessage({
+  entry,
+  name,
+  avatarUrl,
+}: {
+  entry: UserMessageEntry;
+  name?: string;
+  avatarUrl?: string;
+}) {
+  const [imgError, setImgError] = useState(false);
+  const displayName = name ?? 'User';
+  const initial = displayName[0]?.toUpperCase() ?? 'U';
+
+  const icon =
+    avatarUrl && !imgError ? (
+      <img
+        src={avatarUrl}
+        alt=""
+        className="w-3 h-3 rounded-full object-cover shrink-0"
+        onError={() => setImgError(true)}
+      />
+    ) : (
+      <div className="w-3 h-3 rounded-full bg-gradient-to-br from-sky-400 to-blue-600 flex items-center justify-center shrink-0">
+        <span className="text-2xs font-bold text-white">{initial}</span>
+      </div>
+    );
+
   return (
     <div className="p-2.5 rounded-lg bg-sky-500/5 border border-sky-500/15">
       <MessageHeader
-        icon={
-          <div className="w-3 h-3 rounded-full bg-gradient-to-br from-sky-400 to-blue-600 flex items-center justify-center shrink-0">
-            <span className="text-2xs font-bold text-white">U</span>
-          </div>
-        }
-        label="User"
+        icon={icon}
+        label={displayName}
         labelClass="text-sky-400"
         timestamp={entry.timestamp}
       />

--- a/frontend/src/components/messages/UserMessage.tsx
+++ b/frontend/src/components/messages/UserMessage.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import type { UserMessageEntry } from '@cc-spacemolt/shared';
+import { Avatar } from '../common/Avatar';
 import { MessageHeader } from './MessageHeader';
 
 export function UserMessage({
@@ -11,23 +11,12 @@ export function UserMessage({
   name?: string;
   avatarUrl?: string;
 }) {
-  const [imgError, setImgError] = useState(false);
   const displayName = name ?? 'User';
   const initial = displayName[0]?.toUpperCase() ?? 'U';
 
-  const icon =
-    avatarUrl && !imgError ? (
-      <img
-        src={avatarUrl}
-        alt=""
-        className="w-3 h-3 rounded-full object-cover shrink-0"
-        onError={() => setImgError(true)}
-      />
-    ) : (
-      <div className="w-3 h-3 rounded-full bg-gradient-to-br from-sky-400 to-blue-600 flex items-center justify-center shrink-0">
-        <span className="text-2xs font-bold text-white">{initial}</span>
-      </div>
-    );
+  const icon = (
+    <Avatar url={avatarUrl} initial={initial} gradientClasses="from-sky-400 to-blue-600" />
+  );
 
   return (
     <div className="p-2.5 rounded-lg bg-sky-500/5 border border-sky-500/15">

--- a/frontend/src/components/messages/UserMessage.tsx
+++ b/frontend/src/components/messages/UserMessage.tsx
@@ -1,21 +1,15 @@
 import type { UserMessageEntry } from '@cc-spacemolt/shared';
+import { useConfig } from '../../contexts/ConfigContext';
 import { Avatar } from '../common/Avatar';
 import { MessageHeader } from './MessageHeader';
 
-export function UserMessage({
-  entry,
-  name,
-  avatarUrl,
-}: {
-  entry: UserMessageEntry;
-  name?: string;
-  avatarUrl?: string;
-}) {
-  const displayName = name ?? 'User';
+export function UserMessage({ entry }: { entry: UserMessageEntry }) {
+  const { userName, userAvatarUrl } = useConfig();
+  const displayName = userName ?? 'User';
   const initial = displayName[0]?.toUpperCase() ?? 'U';
 
   const icon = (
-    <Avatar url={avatarUrl} initial={initial} gradientClasses="from-sky-400 to-blue-600" />
+    <Avatar url={userAvatarUrl} initial={initial} gradientClasses="from-sky-400 to-blue-600" />
   );
 
   return (

--- a/frontend/src/contexts/AgentContext.tsx
+++ b/frontend/src/contexts/AgentContext.tsx
@@ -1,0 +1,32 @@
+import { createContext, useContext } from 'react';
+import type { ParsedEntry, SessionMeta, AgentStatus } from '@cc-spacemolt/shared';
+
+interface AgentContextValue {
+  entries: ParsedEntry[];
+  sessionMeta: SessionMeta | null;
+  status: AgentStatus;
+  connected: boolean;
+  startAgent: (instructions?: string) => void;
+  sendMessage: (text: string) => void;
+  interrupt: () => void;
+  abort: () => void;
+  resetSession: () => void;
+  selectSession: (sessionId: string) => void;
+}
+
+const noop = () => {};
+
+export const AgentContext = createContext<AgentContextValue>({
+  entries: [],
+  sessionMeta: null,
+  status: 'idle',
+  connected: false,
+  startAgent: noop,
+  sendMessage: noop,
+  interrupt: noop,
+  abort: noop,
+  resetSession: noop,
+  selectSession: noop,
+});
+
+export const useAgent = () => useContext(AgentContext);

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -1,0 +1,12 @@
+import { createContext, useContext } from 'react';
+
+interface ConfigContextValue {
+  agentAvatarUrl?: string;
+  userName?: string;
+  userAvatarUrl?: string;
+  initialPrompt: string;
+}
+
+export const ConfigContext = createContext<ConfigContextValue>({ initialPrompt: '' });
+
+export const useConfig = () => useContext(ConfigContext);

--- a/frontend/src/contexts/GameContext.tsx
+++ b/frontend/src/contexts/GameContext.tsx
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+import type {
+  GameState,
+  GameEvent,
+  GameConnectionStatus,
+  TravelHistoryEntry,
+} from '@cc-spacemolt/shared';
+
+interface GameContextValue {
+  gameState: GameState | null;
+  gameStatus: { status: GameConnectionStatus; message?: string };
+  events: GameEvent[];
+  travelHistory: TravelHistoryEntry[];
+}
+
+export const GameContext = createContext<GameContextValue>({
+  gameState: null,
+  gameStatus: { status: 'connecting' },
+  events: [],
+  travelHistory: [],
+});
+
+export const useGame = () => useContext(GameContext);

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -22,6 +22,9 @@ export function useWebSocket() {
     status: 'connecting',
   });
   const [initialPrompt, setInitialPrompt] = useState('');
+  const [agentAvatarUrl, setAgentAvatarUrl] = useState<string | undefined>(undefined);
+  const [userName, setUserName] = useState<string | undefined>(undefined);
+  const [userAvatarUrl, setUserAvatarUrl] = useState<string | undefined>(undefined);
   const [events, setEvents] = useState<GameEvent[]>([]);
   const [travelHistory, setTravelHistory] = useState<TravelHistoryEntry[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
@@ -107,6 +110,9 @@ export function useWebSocket() {
           break;
         case 'config':
           setInitialPrompt(msg.initialPrompt);
+          setAgentAvatarUrl(msg.agentAvatarUrl);
+          setUserName(msg.userName);
+          setUserAvatarUrl(msg.userAvatarUrl);
           break;
         case 'meta':
           setSessionMeta(msg.meta);
@@ -191,6 +197,9 @@ export function useWebSocket() {
     events,
     travelHistory,
     initialPrompt,
+    agentAvatarUrl,
+    userName,
+    userAvatarUrl,
     startAgent,
     sendMessage,
     interrupt,

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,6 +825,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -842,6 +843,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -859,6 +861,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -876,6 +879,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -893,6 +897,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -910,6 +915,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -927,6 +933,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -944,6 +951,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -961,6 +969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -978,6 +987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -995,6 +1005,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1012,6 +1023,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1029,6 +1041,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1046,6 +1059,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1063,6 +1077,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1080,6 +1095,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1097,6 +1113,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1114,6 +1131,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1131,6 +1149,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1148,6 +1167,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1165,6 +1185,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1182,6 +1203,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1199,6 +1221,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1216,6 +1239,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1233,6 +1257,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1250,6 +1275,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5935,6 +5961,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5956,6 +5983,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5977,6 +6005,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5998,6 +6027,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6019,6 +6049,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6040,6 +6071,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6061,6 +6093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6082,6 +6115,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6103,6 +6137,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6124,6 +6159,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6145,6 +6181,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -217,7 +217,13 @@ export type ClientMessage =
 export type ServerMessage =
   | { type: 'entry'; entry: ParsedEntry }
   | { type: 'meta'; meta: SessionMeta }
-  | { type: 'config'; initialPrompt: string }
+  | {
+      type: 'config';
+      initialPrompt: string;
+      agentAvatarUrl?: string;
+      userName?: string;
+      userAvatarUrl?: string;
+    }
   | { type: 'status'; status: AgentStatus }
   | { type: 'clear_streaming' }
   | { type: 'reset' }


### PR DESCRIPTION
## Summary

Adds support for displaying custom avatar images and names for both the agent and user in the chat interface. Users can now configure their display name and avatar image, and the agent's avatar is automatically loaded from the workspace directory. The avatars are displayed in message.

## Changes

### Backend
- Added two new API endpoints (`/api/agent-avatar` and `/api/user-avatar`) to serve avatar images - Extended the config message to include agent avatar URL, user name, and user avatar URL, resolved from the workspace and configuration
- Added `userName` and `userAvatarPath` options to the app config

### Frontend
- Updated `TextMessage` and `UserMessage` components to accept custom names and avatar image
- Extended the `ServerMessage` config type to include the new profile fields
- Added `Avatar` Compnent for show agent/users icon

The agent's avatar is automatically detected from `{workspacePath}/avatar.png`, while the user's avatar path and name are configurable via the app configuration.
