### PR TITLE
Infinite agent execution

### DIFF
--- a/backend/src/config.test.ts
+++ b/backend/src/config.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { loadConfig, applyCliOverrides, DEFAULT_CONFIG } from './config.js';
+import {
+  loadConfig,
+  applyCliOverrides,
+  DEFAULT_CONFIG,
+  resolveAutoResumeConfig,
+  DEFAULT_AUTO_RESUME_CONFIG,
+} from './config.js';
 import type { CommandLineOptions } from './utils/command-line.js';
 import type { AppConfig } from './config.js';
 
@@ -35,6 +41,25 @@ function makeCliOptions(overrides: Partial<CommandLineOptions> = {}): CommandLin
   };
 }
 
+describe('resolveAutoResumeConfig', () => {
+  it('returns all defaults when called with undefined', () => {
+    expect(resolveAutoResumeConfig()).toEqual(DEFAULT_AUTO_RESUME_CONFIG);
+  });
+
+  it('returns all defaults when called with empty object', () => {
+    expect(resolveAutoResumeConfig({})).toEqual(DEFAULT_AUTO_RESUME_CONFIG);
+  });
+
+  it('merges partial config over defaults', () => {
+    const result = resolveAutoResumeConfig({ enabled: true, timeoutMinutes: 60 });
+    expect(result.enabled).toBe(true);
+    expect(result.timeoutMinutes).toBe(60);
+    expect(result.message).toBe(DEFAULT_AUTO_RESUME_CONFIG.message);
+    expect(result.timeoutMessage).toBe(DEFAULT_AUTO_RESUME_CONFIG.timeoutMessage);
+    expect(result.forceStopDelaySeconds).toBe(DEFAULT_AUTO_RESUME_CONFIG.forceStopDelaySeconds);
+  });
+});
+
 describe('loadConfig', () => {
   it('returns defaults for empty config', () => {
     const config = loadConfig(createTempConfig({}));
@@ -52,6 +77,11 @@ describe('loadConfig', () => {
   it('merges claudeEnv with defaults', () => {
     const config = loadConfig(createTempConfig({ claudeEnv: { FOO: 'bar' } }));
     expect(config.claudeEnv).toEqual({ FOO: 'bar' });
+  });
+
+  it('merges autoResume partial config', () => {
+    const config = loadConfig(createTempConfig({ autoResume: { enabled: true } }));
+    expect(config.autoResume).toEqual({ enabled: true });
   });
 });
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -16,6 +16,34 @@ export interface McpServerConfig {
   headers?: Record<string, string>;
 }
 
+export interface AutoResumeConfig {
+  enabled: boolean;
+  message: string;
+  timeoutMinutes: number;
+  timeoutMessage: string;
+  forceStopDelaySeconds: number;
+}
+
+export const DEFAULT_AUTO_RESUME_CONFIG: AutoResumeConfig = {
+  enabled: false,
+  message: 'continue playing.',
+  timeoutMinutes: 0,
+  timeoutMessage: 'Time limit reached. Please save your progress and end the game session.',
+  forceStopDelaySeconds: 180,
+};
+
+export function resolveAutoResumeConfig(partial?: Partial<AutoResumeConfig>): AutoResumeConfig {
+  if (!partial) return { ...DEFAULT_AUTO_RESUME_CONFIG };
+  return {
+    enabled: partial.enabled ?? DEFAULT_AUTO_RESUME_CONFIG.enabled,
+    message: partial.message ?? DEFAULT_AUTO_RESUME_CONFIG.message,
+    timeoutMinutes: partial.timeoutMinutes ?? DEFAULT_AUTO_RESUME_CONFIG.timeoutMinutes,
+    timeoutMessage: partial.timeoutMessage ?? DEFAULT_AUTO_RESUME_CONFIG.timeoutMessage,
+    forceStopDelaySeconds:
+      partial.forceStopDelaySeconds ?? DEFAULT_AUTO_RESUME_CONFIG.forceStopDelaySeconds,
+  };
+}
+
 export interface AppConfig {
   /** Initial prompt sent to the agent on startup */
   initialPrompt: string;
@@ -61,6 +89,9 @@ export interface AppConfig {
 
   /** Environment variables applied when launching the Claude CLI process */
   claudeEnv?: Record<string, string>;
+
+  /** Auto-resume settings for infinite execution */
+  autoResume?: Partial<AutoResumeConfig>;
 }
 
 export const DEFAULT_CONFIG: AppConfig = {
@@ -191,5 +222,8 @@ function mergeConfig(defaults: AppConfig, partial: Partial<AppConfig>): AppConfi
     claudeEnv: partial.claudeEnv
       ? { ...defaults.claudeEnv, ...partial.claudeEnv }
       : defaults.claudeEnv,
+    autoResume: partial.autoResume
+      ? { ...defaults.autoResume, ...partial.autoResume }
+      : defaults.autoResume,
   };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -6,7 +6,12 @@ import updateNotifier from 'update-notifier';
 import packageJson from '../../package.json' with { type: 'json' };
 
 import type { AppConfig } from './config.js';
-import { loadConfig, applyCliOverrides, defaultConfigDir } from './config.js';
+import {
+  loadConfig,
+  applyCliOverrides,
+  defaultConfigDir,
+  resolveAutoResumeConfig,
+} from './config.js';
 import { ClaudeCliProvider } from './agent/providers/claude-cli.js';
 import { SessionManager } from './state/session-manager.js';
 import { enableDebugLog, debug } from './logger/debug-logger.js';
@@ -111,7 +116,13 @@ async function main() {
     workspacePath,
   });
 
-  const sessionManager = new SessionManager(provider, config.maxLogEntries, logDir);
+  const autoResumeConfig = resolveAutoResumeConfig(config.autoResume);
+  const sessionManager = new SessionManager(
+    provider,
+    config.maxLogEntries,
+    logDir,
+    autoResumeConfig,
+  );
   const gameConnectionManager = new GameConnectionManager(workspacePath);
   const gameData = await loadGameData();
 

--- a/backend/src/logger/debug-logger.ts
+++ b/backend/src/logger/debug-logger.ts
@@ -17,6 +17,7 @@ export type LogGroup =
   | 'game-data'
   | 'spacemolt'
   | 'session-manager'
+  | 'auto-resume'
   | 'server';
 
 const colorByLabel: Record<LogGroup, StyleColor> = {
@@ -28,6 +29,7 @@ const colorByLabel: Record<LogGroup, StyleColor> = {
   'game-data': 'blueBright',
   spacemolt: 'red',
   'session-manager': 'magentaBright',
+  'auto-resume': 'yellowBright',
   server: 'yellow',
 };
 

--- a/backend/src/state/session-manager.test.ts
+++ b/backend/src/state/session-manager.test.ts
@@ -1,0 +1,634 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SessionManager } from './session-manager.js';
+import type { SessionManagerCallbacks } from './session-manager.js';
+import type { AgentProvider, ProviderCallbacks } from '../agent/provider.js';
+import type { AutoResumeConfig } from '../config.js';
+import { DEFAULT_AUTO_RESUME_CONFIG } from '../config.js';
+import type { RuntimeSettings } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createMockProvider(overrides?: Partial<AgentProvider>): AgentProvider {
+  return {
+    name: 'mock',
+    supportsInput: true,
+    sessionId: 'test-session',
+    start: vi.fn<AgentProvider['start']>().mockResolvedValue(undefined),
+    sendMessage: vi.fn(),
+    interrupt: vi.fn(),
+    abort: vi.fn(),
+    setResumeSessionId: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createMockCallbacks(): SessionManagerCallbacks & {
+  settingsHistory: RuntimeSettings[];
+} {
+  const settingsHistory: RuntimeSettings[] = [];
+  return {
+    onEntry: vi.fn(),
+    onMeta: vi.fn(),
+    onStatus: vi.fn(),
+    onClearStreaming: vi.fn(),
+    onError: vi.fn(),
+    onSessionStarted: vi.fn(),
+    onSettingsChange: vi.fn((settings: RuntimeSettings) => {
+      settingsHistory.push(structuredClone(settings));
+    }),
+    settingsHistory,
+  };
+}
+
+function makeAutoResumeConfig(overrides?: Partial<AutoResumeConfig>): AutoResumeConfig {
+  return { ...DEFAULT_AUTO_RESUME_CONFIG, ...overrides };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SessionManager auto-resume', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // getAutoResumeState / getRuntimeSettings
+  // -------------------------------------------------------------------------
+
+  describe('getAutoResumeState', () => {
+    it('returns default disabled state', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig(),
+      );
+      expect(sm.getAutoResumeState()).toEqual({
+        enabled: false,
+        timeoutMinutes: 0,
+        startedAt: null,
+        stopping: false,
+      });
+    });
+
+    it('returns config-based initial state when enabled in config', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true, timeoutMinutes: 60 }),
+      );
+      expect(sm.getAutoResumeState().enabled).toBe(true);
+      expect(sm.getAutoResumeState().timeoutMinutes).toBe(60);
+    });
+  });
+
+  describe('getRuntimeSettings', () => {
+    it('wraps autoResume in RuntimeSettings', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig(),
+      );
+      const settings = sm.getRuntimeSettings();
+      expect(settings).toEqual({ autoResume: sm.getAutoResumeState() });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // setAutoResume
+  // -------------------------------------------------------------------------
+
+  describe('setAutoResume', () => {
+    it('enables auto-resume and sets startedAt', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig(),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      sm.setAutoResume(true, 60);
+
+      const state = sm.getAutoResumeState();
+      expect(state.enabled).toBe(true);
+      expect(state.timeoutMinutes).toBe(60);
+      expect(state.startedAt).toBe('2026-01-01T00:00:00.000Z');
+      expect(cb.onSettingsChange).toHaveBeenCalled();
+    });
+
+    it('disables auto-resume and clears state', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig(),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      sm.setAutoResume(true, 30);
+      sm.setAutoResume(false);
+
+      const state = sm.getAutoResumeState();
+      expect(state.enabled).toBe(false);
+      expect(state.startedAt).toBeNull();
+      expect(state.stopping).toBe(false);
+    });
+
+    it('does not reset startedAt when re-enabling with different timeout', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig(),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      sm.setAutoResume(true, 30);
+      const firstStartedAt = sm.getAutoResumeState().startedAt;
+
+      vi.setSystemTime(new Date('2026-01-01T00:05:00Z'));
+      sm.setAutoResume(true, 60);
+
+      expect(sm.getAutoResumeState().startedAt).toBe(firstStartedAt);
+      expect(sm.getAutoResumeState().timeoutMinutes).toBe(60);
+    });
+
+    it('kicks off auto-resume when enabled while status is done', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(provider, 1000, '/tmp/logs', makeAutoResumeConfig());
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      // Start and complete the agent
+      const startPromise = sm.start('hello');
+      resolveStart!();
+      await startPromise;
+      expect(sm.status).toBe('done');
+
+      // Enable auto-resume after agent is done
+      sm.setAutoResume(true, 0);
+
+      // Advance past the 3-second delay
+      await vi.advanceTimersByTimeAsync(3500);
+
+      // provider.start should have been called again (via resume)
+      expect(provider.start).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // scheduleAutoResume: normal flow
+  // -------------------------------------------------------------------------
+
+  describe('auto-resume on completion', () => {
+    it('auto-resumes 3 seconds after agent completes when enabled', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      // First start
+      const p = sm.start('hello');
+      resolveStart!();
+      await p;
+
+      expect(sm.status).toBe('done');
+      expect(provider.start).toHaveBeenCalledTimes(1);
+
+      // Advance 3s — auto-resume should trigger
+      await vi.advanceTimersByTimeAsync(3500);
+      expect(provider.start).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not auto-resume when disabled', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: false }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      const p = sm.start('hello');
+      resolveStart!();
+      await p;
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(provider.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not auto-resume when interrupted', async () => {
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>(() => {}); // never resolves
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      sm.start('hello');
+
+      // Interrupt sets isResuming and the provider completes
+      sm.interrupt();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      // Only 1 call (the initial start)
+      expect(provider.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Consecutive errors
+  // -------------------------------------------------------------------------
+
+  describe('consecutive errors', () => {
+    it('disables auto-resume after 3 consecutive errors', async () => {
+      const provider = createMockProvider({
+        start: vi.fn().mockRejectedValue(new Error('fail')),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true }),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      // Each start will fail, incrementing consecutiveErrors
+      // After 3 errors, auto-resume should be disabled
+      await sm.start('hello'); // error 1 → scheduleAutoResume
+      await vi.advanceTimersByTimeAsync(3500);
+      // error 2 → scheduleAutoResume
+      await vi.advanceTimersByTimeAsync(3500);
+      // error 3 → disables
+      await vi.advanceTimersByTimeAsync(3500);
+
+      expect(sm.getAutoResumeState().enabled).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Timeout handling
+  // -------------------------------------------------------------------------
+
+  describe('timeout', () => {
+    it('disables auto-resume when timeout exceeded at completion (checked in scheduleAutoResume)', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true, timeoutMinutes: 1 }),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+
+      // Start and complete quickly
+      const p1 = sm.start('hello');
+      resolveStart!();
+      await p1;
+      // Now auto-resume is scheduled (3s) and timeout (60s)
+
+      // Advance 3s — auto-resume fires, starts new provider
+      await vi.advanceTimersByTimeAsync(3500);
+      expect(provider.start).toHaveBeenCalledTimes(2);
+
+      // Now advance well past the timeout while provider is running
+      // (resolveStart from 2nd call hasn't fired, so provider is still running)
+      // Instead, let the 2nd provider complete after the timeout has passed
+      vi.setSystemTime(new Date('2026-01-01T00:02:00Z'));
+      resolveStart!();
+      await vi.advanceTimersByTimeAsync(100);
+
+      // scheduleAutoResume() should detect timeout exceeded at completion
+      expect(sm.getAutoResumeState().enabled).toBe(false);
+    });
+
+    it('sends timeout message when timeout fires while agent is running', async () => {
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation((cb: ProviderCallbacks) => {
+          // Emit system entry to transition to 'running'
+          cb.onMessage({
+            id: 'sys-1',
+            timestamp: new Date().toISOString(),
+            kind: 'system',
+            sessionId: 'test-session',
+            model: 'sonnet',
+            tools: [],
+            mcpServers: [],
+          });
+          // Never resolve — agent keeps running
+          return new Promise<void>(() => {});
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        // Start disabled — we enable via setAutoResume so timeout timer starts
+        makeAutoResumeConfig({ timeoutMessage: 'Time is up!' }),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      sm.start('hello');
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sm.status).toBe('running');
+
+      // Enable auto-resume with 1-min timeout while agent is running
+      sm.setAutoResume(true, 1);
+
+      // Advance past 1 minute timeout
+      vi.advanceTimersByTime(60_000);
+
+      // Should have sent the timeout message
+      expect(provider.sendMessage).toHaveBeenCalledWith('Time is up!');
+      expect(sm.getAutoResumeState().stopping).toBe(true);
+    });
+
+    it('force-stops after grace period when agent does not complete', async () => {
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation((cb: ProviderCallbacks) => {
+          cb.onMessage({
+            id: 'sys-1',
+            timestamp: new Date().toISOString(),
+            kind: 'system',
+            sessionId: 'test-session',
+            model: 'sonnet',
+            tools: [],
+            mcpServers: [],
+          });
+          return new Promise<void>(() => {});
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ forceStopDelaySeconds: 10 }),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      sm.start('hello');
+      await vi.advanceTimersByTimeAsync(100);
+      expect(sm.status).toBe('running');
+
+      // Enable auto-resume with 1-min timeout
+      sm.setAutoResume(true, 1);
+
+      // Advance to timeout
+      vi.advanceTimersByTime(60_000);
+      expect(sm.getAutoResumeState().stopping).toBe(true);
+
+      // Advance past force-stop delay
+      vi.advanceTimersByTime(10_000);
+
+      // Should have called interrupt (force stop)
+      expect(provider.interrupt).toHaveBeenCalled();
+      expect(sm.getAutoResumeState().enabled).toBe(false);
+      expect(sm.getAutoResumeState().stopping).toBe(false);
+    });
+
+    it('gracefully stops when agent completes after timeout message', async () => {
+      let resolveStart: () => void;
+      let startCount = 0;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation((cb: ProviderCallbacks) => {
+          startCount++;
+          cb.onMessage({
+            id: `sys-${startCount}`,
+            timestamp: new Date().toISOString(),
+            kind: 'system',
+            sessionId: 'test-session',
+            model: 'sonnet',
+            tools: [],
+            mcpServers: [],
+          });
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ forceStopDelaySeconds: 60 }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+      sm.start('hello');
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Enable timeout
+      sm.setAutoResume(true, 1);
+
+      // Timeout fires, sends timeout message
+      vi.advanceTimersByTime(60_000);
+      expect(sm.getAutoResumeState().stopping).toBe(true);
+
+      // Agent completes gracefully before force-stop
+      resolveStart!();
+      await vi.advanceTimersByTimeAsync(100);
+
+      // scheduleAutoResume detects stopping=true, disables auto-resume
+      expect(sm.getAutoResumeState().enabled).toBe(false);
+      expect(sm.getAutoResumeState().stopping).toBe(false);
+      // Force-stop should NOT have been called
+      expect(provider.interrupt).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Manual actions
+  // -------------------------------------------------------------------------
+
+  describe('manual actions clear timers', () => {
+    it('abort disables auto-resume entirely', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      const p = sm.start('hello');
+      resolveStart!();
+      await p;
+
+      // Auto-resume is scheduled
+      sm.abort();
+
+      expect(sm.getAutoResumeState().enabled).toBe(false);
+
+      // Advance time — should not auto-resume
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(provider.start).toHaveBeenCalledTimes(1);
+    });
+
+    it('reset disables auto-resume entirely', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      const p = sm.start('hello');
+      resolveStart!();
+      await p;
+
+      sm.reset();
+      expect(sm.getAutoResumeState().enabled).toBe(false);
+    });
+
+    it('manual resume cancels pending auto-resume timer', async () => {
+      let resolveStart: () => void;
+      const provider = createMockProvider({
+        start: vi.fn().mockImplementation(() => {
+          return new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          });
+        }),
+      });
+
+      const sm = new SessionManager(
+        provider,
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig({ enabled: true, message: 'auto msg' }),
+      );
+      sm.setCallbacks(createMockCallbacks());
+
+      // Start and complete → auto-resume is scheduled (3s)
+      const p = sm.start('hello');
+      resolveStart!();
+      await p;
+
+      expect(provider.start).toHaveBeenCalledTimes(1);
+
+      // Manual resume before the 3s timer fires
+      const p2 = sm.resume('manual message');
+      resolveStart!();
+      await p2;
+
+      // provider.start was called with 'manual message' (from resume), not 'auto msg'
+      expect(provider.start).toHaveBeenCalledTimes(2);
+      expect(provider.start).toHaveBeenLastCalledWith(expect.anything(), 'manual message');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // broadcastSettings
+  // -------------------------------------------------------------------------
+
+  describe('broadcastSettings', () => {
+    it('broadcasts settings on each state change', () => {
+      const sm = new SessionManager(
+        createMockProvider(),
+        1000,
+        '/tmp/logs',
+        makeAutoResumeConfig(),
+      );
+      const cb = createMockCallbacks();
+      sm.setCallbacks(cb);
+
+      sm.setAutoResume(true, 60);
+      sm.setAutoResume(false);
+
+      // enable broadcasts once, disable broadcasts once
+      expect(cb.settingsHistory).toHaveLength(2);
+      expect(cb.settingsHistory[0]!.autoResume.enabled).toBe(true);
+      expect(cb.settingsHistory[1]!.autoResume.enabled).toBe(false);
+    });
+  });
+});

--- a/backend/src/state/types.ts
+++ b/backend/src/state/types.ts
@@ -22,5 +22,7 @@ export type {
   PlayerState,
   ShipModule,
   SessionSummary,
+  AutoResumeState,
+  RuntimeSettings,
 } from '@cc-spacemolt/shared';
 export { MAX_GAME_EVENTS } from '@cc-spacemolt/shared';

--- a/frontend/src/components/ClaudePanel.tsx
+++ b/frontend/src/components/ClaudePanel.tsx
@@ -1,8 +1,15 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import type { ParsedEntry, SessionMeta, AgentStatus, ToolResultEntry } from '@cc-spacemolt/shared';
+import type {
+  ParsedEntry,
+  SessionMeta,
+  AgentStatus,
+  ClientMessage,
+  ToolResultEntry,
+  RuntimeSettings,
+} from '@cc-spacemolt/shared';
 import { useStickToBottom } from '../hooks/useStickToBottom';
 import { useSessionList } from '../hooks/useSessionList';
-import { LuSend, LuSquare, LuArrowDown, LuClock, LuPlus } from 'react-icons/lu';
+import { LuSend, LuSquare, LuArrowDown, LuClock, LuPlus, LuChevronDown } from 'react-icons/lu';
 import { EntryRenderer } from './messages/EntryRenderer';
 import { SessionHistoryModal } from './SessionHistoryModal';
 import { SessionCard } from './common/SessionCard';
@@ -11,6 +18,8 @@ import { PanelHeaderButton } from './common/PanelHeaderButton';
 import { IconButton } from './common/IconButton';
 import { ActionButton } from './common/ActionButton';
 import { PanelInput, PanelTextarea } from './common/PanelInput';
+import { Dropdown, type DropdownOption } from './common/Dropdown';
+import { formatDuration } from '../utils/format';
 
 function StatusBadge({
   color,
@@ -41,11 +50,40 @@ interface ClaudePanelProps {
   status: AgentStatus;
   connected: boolean;
   initialPrompt: string;
+  runtimeSettings: RuntimeSettings;
   startAgent: (instructions?: string) => void;
   sendMessage: (text: string) => void;
   interrupt: () => void;
   resetSession: () => void;
   selectSession: (sessionId: string) => void;
+  updateSettings: (settings: (ClientMessage & { type: 'update_settings' })['settings']) => void;
+}
+
+type AutoResumeDropdownValue = 'off' | '0' | '30' | '60' | '180' | '360';
+
+const AUTO_RESUME_OPTIONS: DropdownOption<AutoResumeDropdownValue>[] = [
+  { value: 'off', label: 'OFF' },
+  { value: '0', label: 'No limit', description: 'Run forever' },
+  { value: '30', label: '30 min' },
+  { value: '60', label: '1 hour' },
+  { value: '180', label: '3 hours' },
+  { value: '360', label: '6 hours' },
+];
+
+function useRemainingTime(startedAt: string | null, timeoutMinutes: number): string | null {
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!startedAt || timeoutMinutes <= 0) return;
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, [startedAt, timeoutMinutes]);
+
+  if (!startedAt || timeoutMinutes <= 0) return null;
+  const elapsed = Date.now() - new Date(startedAt).getTime();
+  const remaining = timeoutMinutes * 60_000 - elapsed;
+  if (remaining <= 0) return null;
+  return formatDuration(remaining);
 }
 
 export function ClaudePanel({
@@ -54,11 +92,13 @@ export function ClaudePanel({
   status,
   connected,
   initialPrompt,
+  runtimeSettings,
   startAgent,
   sendMessage,
   interrupt,
   resetSession,
   selectSession,
+  updateSettings,
 }: ClaudePanelProps) {
   const [input, setInput] = useState('');
   const [instructions, setInstructions] = useState('');
@@ -130,6 +170,24 @@ export function ClaudePanel({
   const isRunning = status === 'running' || status === 'starting';
   const supportsInput = sessionMeta?.supportsInput ?? true;
   const isCompacting = sessionMeta?.isCompacting ?? false;
+
+  const { autoResume } = runtimeSettings;
+  const remaining = useRemainingTime(autoResume.startedAt, autoResume.timeoutMinutes);
+
+  const autoResumeValue: AutoResumeDropdownValue = !autoResume.enabled
+    ? 'off'
+    : (String(autoResume.timeoutMinutes) as AutoResumeDropdownValue);
+
+  const handleAutoResumeChange = useCallback(
+    (value: AutoResumeDropdownValue) => {
+      if (value === 'off') {
+        updateSettings({ autoResume: { enabled: false } });
+      } else {
+        updateSettings({ autoResume: { enabled: true, timeoutMinutes: Number(value) } });
+      }
+    },
+    [updateSettings],
+  );
 
   return (
     <div className="flex flex-col h-full">
@@ -258,6 +316,38 @@ export function ClaudePanel({
           </button>
         )}
       </div>
+
+      {/* Auto-resume settings bar */}
+      {status !== 'idle' && status !== 'error' && (
+        <div className="shrink-0 flex items-center justify-between px-3 sm:px-4 py-1.5 border-t border-zinc-800/60 bg-zinc-900/50">
+          <Dropdown
+            options={AUTO_RESUME_OPTIONS}
+            value={autoResumeValue}
+            onChange={handleAutoResumeChange}
+            disabled={!connected}
+            renderTrigger={({ option, isOpen }) => (
+              <span
+                className={`flex items-center gap-1 text-xs transition-colors cursor-pointer ${
+                  autoResume.enabled
+                    ? 'text-amber-400 hover:text-amber-300'
+                    : 'text-zinc-600 hover:text-zinc-400'
+                }`}
+              >
+                <span className="font-medium">
+                  {autoResume.stopping ? 'Shutting down...' : `Auto ${option.label}`}
+                </span>
+                <LuChevronDown
+                  size={11}
+                  className={`transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                />
+              </span>
+            )}
+          />
+          {autoResume.enabled && remaining && !autoResume.stopping && (
+            <span className="text-xs text-zinc-600 tabular-nums">{remaining}</span>
+          )}
+        </div>
+      )}
 
       {/* Input area */}
       {status !== 'error' && (

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,10 +3,12 @@ import type {
   ParsedEntry,
   SessionMeta,
   AgentStatus,
+  ClientMessage,
   GameState,
   GameEvent,
   GameConnectionStatus,
   TravelHistoryEntry,
+  RuntimeSettings,
 } from '@cc-spacemolt/shared';
 import { TopBar } from './TopBar';
 import { MobileTabBar, type TabKey } from './MobileTabBar';
@@ -25,11 +27,13 @@ interface LayoutProps {
   events: GameEvent[];
   travelHistory: TravelHistoryEntry[];
   initialPrompt: string;
+  runtimeSettings: RuntimeSettings;
   startAgent: (instructions?: string) => void;
   sendMessage: (text: string) => void;
   interrupt: () => void;
   resetSession: () => void;
   selectSession: (sessionId: string) => void;
+  updateSettings: (settings: (ClientMessage & { type: 'update_settings' })['settings']) => void;
 }
 
 export function Layout({
@@ -42,11 +46,13 @@ export function Layout({
   events,
   travelHistory,
   initialPrompt,
+  runtimeSettings,
   startAgent,
   sendMessage,
   interrupt,
   resetSession,
   selectSession,
+  updateSettings,
 }: LayoutProps) {
   const [mobileTab, setMobileTab] = useState<TabKey>('claude');
   const [showDetail, setShowDetail] = useState(false);
@@ -79,11 +85,13 @@ export function Layout({
               status={status}
               connected={connected}
               initialPrompt={initialPrompt}
+              runtimeSettings={runtimeSettings}
               startAgent={startAgent}
               sendMessage={sendMessage}
               interrupt={interrupt}
               resetSession={resetSession}
               selectSession={selectSession}
+              updateSettings={updateSettings}
             />
           </div>
           <div className="col-span-4 bg-zinc-900 overflow-hidden">
@@ -112,11 +120,13 @@ export function Layout({
               status={status}
               connected={connected}
               initialPrompt={initialPrompt}
+              runtimeSettings={runtimeSettings}
               startAgent={startAgent}
               sendMessage={sendMessage}
               interrupt={interrupt}
               resetSession={resetSession}
               selectSession={selectSession}
+              updateSettings={updateSettings}
             />
           )}
           {mobileTab === 'events' && <EventsPanel events={events} />}

--- a/frontend/src/components/common/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown.tsx
@@ -1,0 +1,105 @@
+import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react';
+import { LuCheck, LuChevronDown } from 'react-icons/lu';
+
+export interface DropdownOption<T extends string> {
+  value: T;
+  label: string;
+  description?: string;
+}
+
+interface DropdownProps<T extends string> {
+  options: DropdownOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  renderTrigger?: (props: { option: DropdownOption<T>; isOpen: boolean }) => ReactNode;
+  align?: 'left' | 'right';
+  disabled?: boolean;
+}
+
+export function Dropdown<T extends string>({
+  options,
+  value,
+  onChange,
+  renderTrigger,
+  align = 'left',
+  disabled,
+}: DropdownProps<T>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find((o) => o.value === value) ?? options[0]!;
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      setIsOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => document.removeEventListener('mousedown', handleClickOutside);
+    }
+  }, [isOpen, handleClickOutside]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen((v) => !v)}
+        disabled={disabled}
+        className="disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {renderTrigger ? (
+          renderTrigger({ option: selectedOption, isOpen })
+        ) : (
+          <span className="flex items-center gap-1 text-xs text-zinc-400 hover:text-zinc-200 transition-colors cursor-pointer">
+            {selectedOption.label}
+            <LuChevronDown size={12} className={isOpen ? 'rotate-180' : ''} />
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div
+          className={`absolute bottom-full mb-1 z-50 min-w-[160px] rounded-lg border border-zinc-700 bg-zinc-800 shadow-xl shadow-black/40 py-1 ${
+            align === 'right' ? 'right-0' : 'left-0'
+          }`}
+        >
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => {
+                onChange(option.value);
+                setIsOpen(false);
+              }}
+              className="w-full flex items-center gap-2 px-3 py-1.5 text-left text-sm hover:bg-zinc-700/60 transition-colors"
+            >
+              <span className="w-4 shrink-0">
+                {option.value === value && <LuCheck size={14} className="text-amber-400" />}
+              </span>
+              <div className="flex flex-col">
+                <span className={option.value === value ? 'text-zinc-200' : 'text-zinc-400'}>
+                  {option.label}
+                </span>
+                {option.description && (
+                  <span className="text-xs text-zinc-600">{option.description}</span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -825,6 +825,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -842,6 +843,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -859,6 +861,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -876,6 +879,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -893,6 +897,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -910,6 +915,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -927,6 +933,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -944,6 +951,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -961,6 +969,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -978,6 +987,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -995,6 +1005,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1012,6 +1023,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1029,6 +1041,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1046,6 +1059,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1063,6 +1077,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1080,6 +1095,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1097,6 +1113,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1114,6 +1131,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1131,6 +1149,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1148,6 +1167,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1165,6 +1185,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1182,6 +1203,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1199,6 +1221,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1216,6 +1239,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1233,6 +1257,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1250,6 +1275,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5935,6 +5961,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5956,6 +5983,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5977,6 +6005,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5998,6 +6027,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6019,6 +6049,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6040,6 +6071,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6061,6 +6093,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6082,6 +6115,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6103,6 +6137,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6124,6 +6159,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -6145,6 +6181,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -200,6 +200,21 @@ export interface SessionSummary {
 }
 
 // ---------------------------------------------------------------------------
+// Runtime settings (mutable state synced between backend and frontend)
+// ---------------------------------------------------------------------------
+
+export interface AutoResumeState {
+  enabled: boolean;
+  timeoutMinutes: number;
+  startedAt: string | null;
+  stopping: boolean;
+}
+
+export interface RuntimeSettings {
+  autoResume: AutoResumeState;
+}
+
+// ---------------------------------------------------------------------------
 // WebSocket protocol messages
 // ---------------------------------------------------------------------------
 
@@ -211,7 +226,11 @@ export type ClientMessage =
   | { type: 'reset' }
   | { type: 'interrupt' }
   | { type: 'abort' }
-  | { type: 'select_session'; sessionId: string };
+  | { type: 'select_session'; sessionId: string }
+  | {
+      type: 'update_settings';
+      settings: { autoResume?: { enabled: boolean; timeoutMinutes?: number } };
+    };
 
 /** Server -> Client */
 export type ServerMessage =
@@ -219,6 +238,7 @@ export type ServerMessage =
   | { type: 'meta'; meta: SessionMeta }
   | { type: 'config'; initialPrompt: string }
   | { type: 'status'; status: AgentStatus }
+  | { type: 'settings'; settings: RuntimeSettings }
   | { type: 'clear_streaming' }
   | { type: 'reset' }
   | { type: 'state_update'; state: GameState }


### PR DESCRIPTION
## Summary

Add auto-resume for agent execution, with optional timeout-based shutdown for long-running sessions.

## Changes

### Backend

- Add auto-resume state management and timeout handling in `session-manager.ts`
- Add shutdown flow: timeout message → grace period → force stop
- Auto-resume 3 seconds after agent completion
- Disable auto-resume after 3 consecutive failures
- Broadcast runtime settings updates via WebSocket (`onSettingsChange`)
- Clear timers on interrupt/abort/reset

- Add `AutoResumeConfig` and `resolveAutoResumeConfig()` in `config.ts`
- Extend `AppConfig` with optional `autoResume`
- Extend shared message/types for runtime settings (`update_settings`, `settings`)
- Add `formatDuration()` helper and `auto-resume` debug log group

### Frontend

- Add auto-resume timeout dropdown to `ClaudePanel.tsx`
  - off / no limit / 30 / 60 / 180 / 360 min
- Show remaining time until timeout
- Show `Shutting down...` during grace period
- Show controls only while the agent is running
- Add reusable `Dropdown.tsx` (descriptions, custom trigger, Escape/click-outside support)
